### PR TITLE
Move window creation to startWorld function

### DIFF
--- a/src/World/World.cpp
+++ b/src/World/World.cpp
@@ -308,6 +308,13 @@ namespace CGEngine {
         }
     }
 
+    void World::startWorld() {
+        window = new RenderWindow(VideoMode(screen->getSize()), appTitle);
+        screen->window = window;
+        input->setWindow(window);
+        window->setView(*currentView);
+    }
+
     void World::renderWorld() {
         window->clear();
         render();
@@ -330,7 +337,7 @@ namespace CGEngine {
         }
     }
 
-    void World::update() {
+    void World::runWorld() {
         while (window->isOpen()) {
             deleted.clear();
             updateTime();

--- a/src/World/World.h
+++ b/src/World/World.h
@@ -21,7 +21,8 @@ namespace CGEngine {
         //World Window
         Screen* createScreen(Vector2u windowSize, string appTitle);
         RenderWindow* getWindow() const;
-        void update();
+        void runWorld();
+        void startWorld();
         void renderWorld();
         //World Destruction
         void end();

--- a/src/World/WorldInstance.cpp
+++ b/src/World/WorldInstance.cpp
@@ -9,7 +9,8 @@ namespace CGEngine {
     Screen* screen = new Screen({ 1200,1000 }, "CGEngine App");
     InputMap* input = new InputMap(world->getWindow());
     World* world = new World({ 1200,1000 },"");
-    function<void()> drawWorld = []() { world->update(); };
+    function<void()> updateWorld = []() { world->runWorld(); };
+    function<void()> beginWorld = []() { world->startWorld(); };
     Logging logging;
 
     const char* keys[] = {

--- a/src/World/WorldInstance.h
+++ b/src/World/WorldInstance.h
@@ -12,11 +12,11 @@ namespace CGEngine {
 	extern GlobalTime time;
 	extern InputMap* input;
 	extern Screen* screen;
-	extern RenderWindow frame;
 	extern TextureCache* textures;
 	extern FontCache* fonts;
 	extern Font* defaultFont;
-	extern function<void()> drawWorld;
+	extern function<void()> updateWorld;
+	extern function<void()> beginWorld;
 	extern Logging logging;
 
 	extern const char* keys[];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,11 +8,8 @@
 using namespace CGEngine;
 
 int main() {
-    RenderWindow* frame = new RenderWindow(VideoMode({ 1200, 1000 }), "Test");
-    screen->window = frame;
-    world->window = frame;
-    input->setWindow(frame);
-    screen->window->setView(*(world->getCurrentView()));
+    beginWorld();
+
     Body* worldGrid = nullptr;
     vector<int> tileTypes = { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54 };
     int assignedType = 0;
@@ -168,6 +165,7 @@ int main() {
     rectObj->setIntersectEnabled(true);
     rectObj->get()->setFillColor(Color(80, 80, 80,0));
     rectObj->translate({ 48,48 });
+
     //The world steps through the Body hierarchy from the world root and renders each body
-    drawWorld();
+    updateWorld();
 }


### PR DESCRIPTION
Window creation was initially done manually in main as a workaround for an unexpected bug. Now it occurs in the world.startWorld method (which is also called in main).