### PR TITLE
Simplify window construction, remove unused includes in main

### DIFF
--- a/src/Body/Body.cpp
+++ b/src/Body/Body.cpp
@@ -255,11 +255,11 @@ namespace CGEngine {
     }
 
     Vector2f Body::viewToGlobal(Vector2i input) const {
-        return world->getWindow()->mapPixelToCoords(input);
+        return screen->getWindow()->mapPixelToCoords(input);
     }
 
     Vector2f Body::viewToLocal(Vector2i input) const {
-        return globalToLocal(world->viewToGlobal(input));
+        return globalToLocal(screen->viewToGlobal(input));
     }
 
     bool Body::lineIntersects(Vector2f lineStart, Vector2f lineEnd) {

--- a/src/Scripts/CommonScripts.cpp
+++ b/src/Scripts/CommonScripts.cpp
@@ -26,7 +26,7 @@ namespace CGEngine {
             V2f delta = evtArgs.direction * evtArgs.speed * time.getDeltaSec();
             args.caller->translate(delta, true);
             if (evtArgs.viewBound) {
-                world->moveView(delta);
+                screen->moveView(delta);
             }
         }
         args.caller->callScriptsWithData("OnTranslate", stack<any>({ evtArgs.direction }));
@@ -41,7 +41,7 @@ namespace CGEngine {
             Angle delta = degrees(evtArgs.degreesPerSecond * time.getDeltaSec());
             args.caller->rotate(delta);
             if (evtArgs.viewBound) {
-                world->rotateView(delta);
+                screen->rotateView(delta);
             }
             args.caller->callScriptsWithData("OnRotate", stack<any>({ evtArgs.degreesPerSecond }));
     };

--- a/src/TilemapScene.cpp
+++ b/src/TilemapScene.cpp
@@ -96,7 +96,7 @@ namespace CGEngine {
                     MouseReleaseInput* mouseEvt = args.script->pullOutInputPtr<MouseReleaseInput>();
                     if (mouseEvt == nullptr || clickedTilemapPos == nullopt) return;
 
-                    V2f mouseGlobalPos = world->viewToGlobal(mouseEvt->position);
+                    V2f mouseGlobalPos = screen->viewToGlobal(mouseEvt->position);
                     Body* worldGrid = world->bodies.get(gridId);
                     if (worldGrid->contains(mouseGlobalPos)) {
                         SpriteAnimBody* body = new SpriteAnimBody("animation.png", AnimationParameters({ 32,32 }, 30.f), Transformation(), worldGrid);

--- a/src/World/Screen.cpp
+++ b/src/World/Screen.cpp
@@ -1,9 +1,13 @@
 #include "Screen.h"
 
 namespace CGEngine {
-    Screen::Screen(V2f size, string title, bool fullscreen) {
-        //createWindow(size, title, fullscreen);
+    Screen::Screen(V2f size, string title, bool fullscreen) : windowTitle(title) {
         setSize(size);
+        windowTitle = title;
+    }
+
+    string Screen::getWindowTitle() {
+        return windowTitle;
     }
 
     void Screen::setSize(V2f s) {
@@ -63,8 +67,40 @@ namespace CGEngine {
         return window;
     }
 
-    void Screen::createWindow(V2f size, string title, bool fullscreen) {
-        window = new RenderWindow(sf::VideoMode({ 1920u, 1080u }), title);
-        setSize(size);
+    RenderWindow* Screen::createWindow() {
+        window = new RenderWindow(VideoMode(size), windowTitle);
+        initView();
+        return window;
+    }
+
+    void Screen::initView() {
+        currentView = new View(size / 2.f, size);
+        window->setView(*currentView);
+    }
+
+    View* Screen::getCurrentView() {
+        return currentView;
+    }
+
+    void Screen::moveView(Vector2f delta) {
+        currentView->move(delta);
+        window->setView(*currentView);
+    }
+
+    void Screen::rotateView(Angle delta) {
+        currentView->rotate(delta);
+        window->setView(*currentView);
+    }
+
+    void Screen::zoomView(float delta) {
+        currentView->zoom(delta);
+        window->setView(*currentView);
+    }
+
+    Vector2f Screen::viewToGlobal(Vector2i pixels) {
+        if (window != nullptr) {
+            return window->mapPixelToCoords(pixels);
+        }
+        return Vector2f();
     }
 }

--- a/src/World/Screen.h
+++ b/src/World/Screen.h
@@ -9,7 +9,10 @@ namespace CGEngine {
     class Screen {
     public:
         Screen(V2f size, string title, bool fullscreen = false);
-        void setSize(V2f s);
+        //Window
+        RenderWindow* getWindow() const;
+        string getWindowTitle();
+        //Size
         V2f getSize() const;
         V2f getCenter() const;
         V2f getTopLeft() const;
@@ -20,10 +23,20 @@ namespace CGEngine {
         V2f getBottomCenter() const;
         V2f getLeftCenter() const;
         V2f getRightCenter() const;
-        RenderWindow* getWindow() const;
-        RenderWindow* window;
+        //Current View
+        View* getCurrentView();
+        void moveView(Vector2f delta);
+        void rotateView(Angle delta);
+        void zoomView(float delta);
+        Vector2f viewToGlobal(Vector2i pixels);
     protected:
-        void createWindow(V2f size, string title, bool fullscreen);
+        friend class World;
+        //Window
+        RenderWindow* window;
+        RenderWindow* createWindow();
+        string windowTitle;
+        //Size
+        void setSize(V2f s);
         V2f size;
         V2f center;
         V2f topLeft;
@@ -34,5 +47,8 @@ namespace CGEngine {
         V2f bottomCenter;
         V2f rightCenter;
         V2f leftCenter;
+        //Current View
+        View* currentView = nullptr;
+        void initView();
     };
 }

--- a/src/World/World.h
+++ b/src/World/World.h
@@ -12,15 +12,6 @@ namespace CGEngine {
     class World {
     public:
         World();
-        World(string title);
-        World(Vector2u windowSize);
-        World(Vector2u windowSize, string title);
-
-        string appTitle;
-
-        //World Window
-        Screen* createScreen(Vector2u windowSize, string appTitle);
-        RenderWindow* getWindow() const;
         
         //World state
         void runWorld();
@@ -30,13 +21,6 @@ namespace CGEngine {
         //Scripts
         void callScripts(string scriptDomain, Body* body = nullptr);
         void addDefaultExitActuator();
-
-        //Current View
-        View* getCurrentView();
-        void moveView(Vector2f delta);
-        void rotateView(Angle delta);
-        void zoomView(float delta);
-        Vector2f viewToGlobal(Vector2i pixels);
 
         //Utility
         vector<Body*> zRayCast(Vector2f worldPos, optional<int> startZ = nullopt, int distance = -1, bool backward = false, bool linecast = false);
@@ -78,20 +62,21 @@ namespace CGEngine {
         Body* getRoot();
         Body* findBodyByName(string name);
         void addWorldScript(string domain, Script* script);
-
-        RenderWindow* window = nullptr;
     private:
+        RenderWindow* window = nullptr;
+
         //World Root
         Body* root = nullptr;
-
-        //Current View
-        View* currentView = nullptr;
         
-        //Update/World State
+        //World State
+        //Start World
+        void initSceneList();
+        //Update World
         void updateTime();
         void startUninitializedBodies();
         void renderWorld();
         void render();
+        //End World
         void endWorld(Body* body);
 
         //Bodies

--- a/src/World/WorldInstance.cpp
+++ b/src/World/WorldInstance.cpp
@@ -2,17 +2,21 @@
 #include "../TilemapScene.cpp"
 
 namespace CGEngine {
+    Logging logging;
     GlobalTime time;
     Renderer renderer;
     TextureCache* textures = new TextureCache();
     FontCache* fonts = new FontCache();
     Font* defaultFont = fonts->getDefaultFont();
     InputMap* input = new InputMap();
+    
+    //Window Size & Window Title
     Screen* screen = new Screen({ 1200,1000 }, "CGEngine App");
-    World* world = new World({ 1200,1000 },"");
+    //List of Scenes to create, add to World and load sceneList[0]
     vector<Scene*> sceneList = { new TilemapScene() };
+
+    World* world = new World();
     function<void()> beginWorld = []() { world->startWorld(); world->runWorld(); };
-    Logging logging;
 
     const char* keys[] = {
         "a",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,4 @@
 #include "World/WorldInstance.h"
-#include "Scripts/CommonScripts.h"
-#include "Body/ButtonBody.h"
-#include "Body/SpriteAnimBody.h"
-#include "TilemapScene.cpp"
-#include <iostream>
-#include <fstream>
-
 using namespace CGEngine;
 
 int main() {


### PR DESCRIPTION
- Move window construction code to be mostly managed by Screen but initialized by World in startWorld.
- Move View code from World to Screen (more logical), including setting View size and window's View.