### PR TITLE
Easier Data in Behaviors/Scripts & better world setup

### DIFF
--- a/src/Behavior/Behavior.h
+++ b/src/Behavior/Behavior.h
@@ -87,7 +87,6 @@ namespace CGEngine {
 			process.setData(key, value);
 		}
 
-
 	private:
 		Body* owner;
 		ScriptMap scripts;

--- a/src/Scripts/Script.h
+++ b/src/Scripts/Script.h
@@ -36,73 +36,33 @@ namespace CGEngine {
 			scriptEvent(ScArgs(this, caller, behavior));
 		}
 
-		//template <typename T>
-		//T pullOutInput() {
-		//	static T test;
-		//	return input.pullOut<T>().value_or(test);
-		//}
-		//
-		//template <typename T>
-		//optional<T> pullOutOptionalInput() {
-		//	static T test;
-		//	return input.pullOut<T>();
-		//}
-		//
-		//template <typename T>
-		//T peekInput() {
-		//	static T test;
-		//	return input.peek<T>().value_or(test);
-		//}
-		//
-		//template <typename T>
-		//optional<T> peekOptionalInput() {
-		//	static T test;
-		//	return input.peek<T>();
-		//}
-		//
-		//template <typename T>
-		//T pullOutOutput() {
-		//	static T test;
-		//	return output.pullOut<T>().value_or(test);
-		//}
-		//
-		//template <typename T>
-		//optional<T> pullOutOptionalOutput() {
-		//	static T test;
-		//	return output.pullOut<T>();
-		//}
-		//
-		//template <typename T>
-		//T peekOutput() {
-		//	static T test;
-		//	return output.peek<T>().value_or(test);
-		//}
-		//
-		//template <typename T>
-		//optional<T> peekOptionalOutput() {
-		//	static T test;
-		//	return output.peek<T>();
-		//}
-		//
-		//template <typename T>
-		//T* pullOutInputPtr() {
-		//	return input.pullOut<T*>().value_or(nullptr);
-		//}
-		//
-		//template <typename T>
-		//T* peekInputPtr() {
-		//	return input.peek<T*>().value_or(nullptr);
-		//}
-		//
-		//template <typename T>
-		//T* pullOutOutputPtr() {
-		//	return output.pullOut<T*>().value_or(nullptr);
-		//}
-		//
-		//template <typename T>
-		//T* peekOutputPtr() {
-		//	return output.peek<T*>().value_or(nullptr);
-		//}
+		template<typename T>
+		T getInputData(string key) {
+			return input.getData<T>(key);
+		}
+
+		template<typename T>
+		T getOutputData(string key) {
+			return output.getData<T>(key);
+		}
+
+		template<typename T>
+		T* getInputDataPtr(string key) {
+			return input.getDataPtr<T>(key);
+		}
+
+		template<typename T>
+		T* getOutputDataPtr(string key) {
+			return output.getDataPtr<T>(key);
+		}
+
+		void setInputData(string key, any value) {
+			input.setData(key, value);
+		}
+
+		void setOutputData(string key, any value) {
+			output.setData(key, value);
+		}
 
 		void setInput(DataMap stack) { input = stack; }
 		void setOutput(DataMap stack) { output = stack; }

--- a/src/TilemapScene.cpp
+++ b/src/TilemapScene.cpp
@@ -7,18 +7,19 @@
 namespace CGEngine {
 	class TilemapScene : public Scene {
     public:
-        TilemapScene() { loadEvent = new Script(mainEvt); displayName = "TilemapScene"; }
+        TilemapScene() { 
+            loadEvent = new Script(mainEvt); 
+            displayName = "TilemapScene"; 
+        }
 
-        id_t gridId = 0U;
         vector<int> tileTypes = { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54 };
         int assignedType = 0;
         optional<Vector2f> clickedTilemapPos = nullopt;
         string tilemapDataPath = "mapData_.txt";
-        Behavior* beh = new AnimationBehavior(nullptr, "ts", { 32,32 });
 
         ScriptEvent saveTilemapDataEvt = [](ScArgs args) { args.caller->get<Tilemap*>()->saveMapData(); };
         ScriptEvent tileClickEvt = [this](ScArgs args) {
-            MouseReleaseInput* mouseEvt = args.script->getInput().getDataPtr<MouseReleaseInput>("evt");
+            MouseReleaseInput* mouseEvt = args.script->getInputDataPtr<MouseReleaseInput>("evt");
             Tilemap* tilemap = args.caller->get<Tilemap*>();
             if (mouseEvt == nullptr || tilemap == nullptr) return;
 
@@ -28,13 +29,12 @@ namespace CGEngine {
             //Set assignedType on RMB or assign the tile type on LMB
             if (mouseEvt->button == Mouse::Button::Right) {
                 assignedType = tilemap->query(tileId);
-            }
-            else {
+            } else {
                 tilemap->assign(tileId, assignedType);
             }
         };
         ScriptEvent loadTilemapDataEvt = [this](ScArgs args) {
-            vector<string> strings = args.script->getInput().getData<vector<string>>("args");
+            vector<string> strings = args.script->getInputData<vector<string>>("args");
             Tilemap* tilemap = args.caller->get<Tilemap*>();
             if (strings.size() < 1 && tilemap == nullptr) return;
 
@@ -43,7 +43,7 @@ namespace CGEngine {
         };
 
         ScriptEvent toolboxTileClickEvt = [this](ScArgs args) {
-            MouseReleaseInput* mouseEvt = args.script->getInput().getDataPtr<MouseReleaseInput>("evt");
+            MouseReleaseInput* mouseEvt = args.script->getInputDataPtr<MouseReleaseInput>("evt");
             Tilemap* tilemap = args.caller->get<Tilemap*>();
             if (mouseEvt == nullptr || tilemap == nullptr) return;
 
@@ -57,10 +57,10 @@ namespace CGEngine {
         ScriptEvent mainEvt = [this](ScArgs args) {
             ScriptEvent tilemapConstruction = [this](ScArgs args) {
                 //Create the Body and setup its properties, including alignment and transform
-                gridId = world->create(new Tilemap("tilemap.png", { 32,32 }, { 10,10 }, vector<int>(), tilemapDataPath), new Script([&](ScArgs args) {
+                id_t gridId = world->create(new Tilemap("tilemap.png", { 32,32 }, { 10,10 }, vector<int>(), tilemapDataPath), new Script([&](ScArgs args) {
                     //Basic body properties
                     args.caller->setName("map");
-                    args.caller->moveToAlignment({ 0.5, 0.5 });
+                    args.caller->moveToAlignment({ 0.5, 0 });
                     args.caller->setScale({ 1.5f,1.5f });
 
                     //Add OnDelete script to save map data on game end or tilemap deleted
@@ -76,7 +76,7 @@ namespace CGEngine {
                     args.caller->addScript("LoadMapData", new Script(loadTilemapDataEvt));
                     //Add "SaveMapData" that expects no input strings
                     args.caller->addScript("SaveMapData", new Script(saveTilemapDataEvt));
-                    }));
+                }));
 
                 id_t toolboxId = world->create(new Tilemap("tilemap.png", { 32,32 }, { 8,7 }, tileTypes), new Script([&](ScArgs args) {
                     //Basic body properties
@@ -88,7 +88,7 @@ namespace CGEngine {
 
                     //Add a left click listener and the toolboxTileClickScript script
                     args.caller->addOverlapMouseReleaseScript(new Script(toolboxTileClickEvt), Mouse::Button::Left);
-                    }));
+                }));
 
                 //ScriptEvent clickUpdateScript = [this](ScArgs args) {
                 //    MouseReleaseInput* mouseEvt = args.script->getInput().getDataPtr<MouseReleaseInput>("evt");

--- a/src/Types/Types.h
+++ b/src/Types/Types.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "SFML/Graphics.hpp"
 using namespace sf;
+using namespace std;
 
 namespace CGEngine {
     class Body;
@@ -87,5 +88,13 @@ namespace CGEngine {
         Color fillColor = Color(80, 80, 80);
         Color outlineColor = Color();
         float outlineWidth = 0;
+    };
+
+    struct WindowParameters {
+        WindowParameters(Vector2i windowSize, string windowTitle) :windowTitle(windowTitle), windowSize(windowSize) {
+
+        };
+        string windowTitle;
+        Vector2i windowSize;
     };
 }

--- a/src/World/Screen.cpp
+++ b/src/World/Screen.cpp
@@ -1,9 +1,19 @@
 #include "Screen.h"
 
 namespace CGEngine {
-    Screen::Screen(V2f size, string title, bool fullscreen) : windowTitle(title) {
+    Screen::Screen(Vector2i size, string title, bool fullscreen) : windowTitle(title) {
+        setWindowParameters(size, title);
+    }
+
+    void Screen::setWindowParameters(Vector2i size, optional<string> title) {
         setSize(size);
-        windowTitle = title;
+        if (title.has_value()) {
+            windowTitle = title.value();
+        }
+    }
+
+    void Screen::setWindowParameters(WindowParameters windowParams) {
+        setWindowParameters(windowParams.windowSize, windowParams.windowTitle);
     }
 
     string Screen::getWindowTitle() {

--- a/src/World/Screen.h
+++ b/src/World/Screen.h
@@ -2,13 +2,16 @@
 
 #include "SFML/Graphics.hpp"
 #include "../Types/V2.h"
+#include "../Types/Types.h"
 using namespace std;
 using namespace sf;
 
 namespace CGEngine {
     class Screen {
     public:
-        Screen(V2f size, string title, bool fullscreen = false);
+        Screen(Vector2i size, string title, bool fullscreen = false);
+        void setWindowParameters(Vector2i size, optional<string> title = "");
+        void setWindowParameters(WindowParameters windowParams);
         //Window
         RenderWindow* getWindow() const;
         string getWindowTitle();

--- a/src/World/World.cpp
+++ b/src/World/World.cpp
@@ -266,7 +266,8 @@ namespace CGEngine {
     }
 
     void World::startWorld() {
-        //Create window (via Screen) and set InputMap's window
+        //Create window (via Screen and using the static WindowParameters) and set InputMap's window
+        screen->setWindowParameters(windowParameters);
         window = screen->createWindow();
         input->setWindow(window);
         //Add scenes from sceneList to world and load sceneList[0]

--- a/src/World/WorldInstance.cpp
+++ b/src/World/WorldInstance.cpp
@@ -2,6 +2,10 @@
 #include "../TilemapScene.cpp"
 
 namespace CGEngine {
+    //Size and name to give created window
+    WindowParameters windowParameters = WindowParameters({ 1000,500 }, "CGEngine App");
+    //List of Scenes to create, add to World and load sceneList[0]
+    vector<Scene*> sceneList = { };
     Logging logging;
     GlobalTime time;
     Renderer renderer;
@@ -11,51 +15,9 @@ namespace CGEngine {
     InputMap* input = new InputMap();
     
     //Window Size & Window Title
-    Screen* screen = new Screen({ 1200,1000 }, "CGEngine App");
-    //List of Scenes to create, add to World and load sceneList[0]
-    vector<Scene*> sceneList = { new TilemapScene() };
-
+    Screen* screen = new Screen(windowParameters.windowSize, windowParameters.windowTitle);
     World* world = new World();
     function<void()> beginWorld = []() { world->startWorld(); world->runWorld(); };
-
-    const char* keys[] = {
-        "a",
-        "b",
-        "c",
-        "d",
-        "e",
-        "f",
-        "g",
-        "h",
-        "i",
-        "j",
-        "k",
-        "l",
-        "m",
-        "n",
-        "o",
-        "p",
-        "q",
-        "r",
-        "s",
-        "t",
-        "u",
-        "v",
-        "w",
-        "x",
-        "y",
-        "z",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "0"
-    };
 
     const string onUpdateEvent = "update";
     const string onStartEvent = "start";

--- a/src/World/WorldInstance.h
+++ b/src/World/WorldInstance.h
@@ -7,6 +7,7 @@
 #include "../ResourceCaches/TextureCache.h"
 
 namespace CGEngine {
+	extern WindowParameters windowParameters;
 	extern Renderer renderer;
 	extern World* world;
 	extern GlobalTime time;
@@ -20,7 +21,6 @@ namespace CGEngine {
 	extern vector<Scene*> sceneList;
 	extern Logging logging;
 
-	extern const char* keys[];
 	extern const string onUpdateEvent;
 	extern const string onStartEvent;
 	extern const string onDeleteEvent;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
 #include "World/WorldInstance.h"
+#include "TilemapScene.cpp"
 using namespace CGEngine;
 
 int main() {
+    sceneList.push_back(new TilemapScene());
     beginWorld();
 }


### PR DESCRIPTION
- Reduces the number of manual object references needed to get/set DataMap members in Behaviors and Scripts
- World.startWorld now sets Screen.size/title to the static WindowParameters values when creating the window so that the user can set these before calling beginWorld (such as in main.cpp)
- Similarly, sceneList is blank by default and, to be used, expects the user to assign at least one Scene with a loadEvent to it before calling beginWorld (such as in main.cpp)