### PR TITLE
Replace Tilemap bounds calls in Body with BoundsBehavior

### DIFF
--- a/src/Behavior/BoundsBehavior.cpp
+++ b/src/Behavior/BoundsBehavior.cpp
@@ -1,0 +1,10 @@
+#include "BoundsBehavior.h"
+
+namespace CGEngine {
+	BoundsBehavior::BoundsBehavior(Body* owning, function<FloatRect(const Body*)> getGlobalBounds, function<FloatRect(const Body*)> getLocalBounds) : Behavior(owning) {
+		this->getGlobalBounds = getGlobalBounds;
+		this->getLocalBounds = getLocalBounds;
+		getOwner()->getBodyGlobalBounds = getGlobalBounds;
+		getOwner()->getBodyLocalBounds = getLocalBounds;
+	}
+}

--- a/src/Behavior/BoundsBehavior.h
+++ b/src/Behavior/BoundsBehavior.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Behavior.h"
+#include "../World/World.h"
+#include <functional>
+using namespace std;
+
+namespace CGEngine {
+	class BoundsBehavior : public Behavior {
+	public:
+		BoundsBehavior(Body* owner, function<FloatRect(const Body*)> getGlobalBounds, function<FloatRect(const Body*)> getLocalBounds);
+		function<FloatRect(const Body*)> getLocalBounds = [](const Body* body) {
+			return FloatRect({ 0,0 }, { 1,1 });
+		};
+		function<FloatRect(const Body*)> getGlobalBounds = [](const Body* body) {
+			return FloatRect({ 0,0 }, { 1,1 });
+		};
+
+	};
+}

--- a/src/Body/Body.cpp
+++ b/src/Body/Body.cpp
@@ -78,6 +78,10 @@ namespace CGEngine {
         bodyParams.name = name;
     }
 
+    Transformable* Body::get() const {
+        return entity;
+    }
+
     void Body::update(function<void(Shape*)> script, bool updateChildren) {
         update<Shape*>(script, updateChildren);
     }
@@ -135,9 +139,6 @@ namespace CGEngine {
             else if (Sprite* t = dynamic_cast<Sprite*>(entity)) {
                 return (getGlobalTransform()).transformRect(t->getLocalBounds());
             }
-            else if (Tilemap* t = dynamic_cast<Tilemap*>(entity)) {
-                return (getGlobalTransform()).transformRect(t->getLocalBounds());
-            }
         } else {
             if (this == world->getRoot()) {
                 return FloatRect({ 0,0 }, screen->getSize());
@@ -155,9 +156,6 @@ namespace CGEngine {
                 return t->getLocalBounds();
             }
             else if (Sprite* t = dynamic_cast<Sprite*>(entity)) {
-                return t->getLocalBounds();
-            }
-            else if (Tilemap* t = dynamic_cast<Tilemap*>(entity)) {
                 return t->getLocalBounds();
             }
         } else {

--- a/src/Body/Body.h
+++ b/src/Body/Body.h
@@ -7,7 +7,6 @@
 #include "../Scripts/ScriptMap.h"
 #include "../World/InputMap.h"
 #include "../Timers/TimerMap.h"
-#include "../Drawables/Tilemap.h"
 #include "../Behavior/Behavior.h"
 #include "../Types/UniqueDomain.h"
 #include "../Types/DataMap.h"
@@ -78,6 +77,8 @@ namespace CGEngine {
         T get() {
             return dynamic_cast<T>(entity);
         }
+
+        Transformable* get() const;
 
         /// <summary>
         /// Call the script on the entity, cast to the supplied type, and on each child recursively (if updateChildren is true)


### PR DESCRIPTION
- Created a BoundsBehavior Behavior subclass that takes two functors for getLocalBounds and getWorldBounds that, when the Behavior is created and added to a body, also automatically adds those two functors as the Body's getBodyLocalBounds and getBodyWorldBounds functors. This allows custom Drawables (like Tilemap, in this case) to correctly provide their local and global bounds to a Body.
- Removed calls to Tilemap.getLocalBounds and Tilemap.getGlobalBounds in Body.geLocalBounds and Body.getGlobalBounds. Now, a Body with a Tilemap entity (which is a non-SFML entity), must assign a BoundsBehavior to the Body to get the correct bounds information.
- Ideally, Tilemap.h & Tilemap.css will not be in the core package, in case client applications don't need this Tilemap.