### PR TITLE
Add missing CGEngine namespace to GlobalTime.cpp

### DIFF
--- a/src/Core/Time/GlobalTime.cpp
+++ b/src/Core/Time/GlobalTime.cpp
@@ -1,13 +1,15 @@
 #include "GlobalTime.h"
 
-sec_t GlobalTime::getElapsedSec() {
-	return runningClock.getElapsedTime().asSeconds();
-}
+namespace CGEngine {
+	sec_t GlobalTime::getElapsedSec() {
+		return runningClock.getElapsedTime().asSeconds();
+	}
 
-sec_t GlobalTime::getDeltaSec() const {
-	return deltaSec;
-}
+	sec_t GlobalTime::getDeltaSec() const {
+		return deltaSec;
+	}
 
-void GlobalTime::updateDeltaTime() {
-	deltaSec = frameClock.restart().asSeconds();
+	void GlobalTime::updateDeltaTime() {
+		deltaSec = frameClock.restart().asSeconds();
+	}
 }


### PR DESCRIPTION
- Just-added GlobalTime.cpp was missing a CGEngine namespace