### PR TITLE
Add V3 and Mesh V3 translate, rotate, scale support

### DIFF
--- a/src/Core/Mesh/Mesh.h
+++ b/src/Core/Mesh/Mesh.h
@@ -1,18 +1,20 @@
 #pragma once
 
 #include <SFML/OpenGL.hpp>
+#include "../Types/V3.h"
 #include "../Engine/Engine.h"
 
 namespace CGEngine {
 	class Mesh : public Transformable{
 	public:
-		Mesh(vector<GLfloat> vertices, Texture* texture = nullptr, float depth = 0, bool screenSpaceRendering = false, bool textureCoordinatesEnabled = true);
+		Mesh(vector<GLfloat> vertices, V3f position = { 0,0,0 }, V3f rotation = { 0,0,0 }, V3f scale = { 0,0,0 }, Texture * texture = nullptr, bool screenSpaceRendering = false, bool textureCoordinatesEnabled = true);
 
 		void render(Transform parentTransform);
 		vector<GLfloat> vertices;
 		Texture* meshTexture;
-		float depth = 0;
-		float height = 1;
+		V3f position = { 0,0,0 };
+		V3f eulerRotation = { 0,0,0 };
+		V3f scale = { 1,1,1 };
 	private:
 		bool textureCoordinatesEnabled = true;
 		bool screenSpaceRendering = false;

--- a/src/Core/Types/V3.h
+++ b/src/Core/Types/V3.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "V3.h"
+
+namespace CGEngine {
+    template<typename T>
+    class V3 {
+    public:
+        V3(T x = 0.f, T y = 0.f, T z = 0.f) :x(x), y(y), z(z) {};
+        T x, y, z = 0.f;
+    };
+
+    class V3f : public V3<float> {
+    public:
+        V3f(float x = 0.f, float y = 0.f, float z = 0.f) :x(x), y(y), z(z) {};
+        float x, y, z = 0.f;
+    };
+}


### PR DESCRIPTION
- Introduces V3 and V3f
- Mesh combines SFML Global Transform position, rotation, and scale with its own V3 position, eulerRotation, and scale
- Replaces depth and height on Mesh with position.z and scale.z, respectively