### PR TITLE
Per mesh normals & textures, fix vertex coloring

### DIFF
--- a/src/Core/Mesh/Mesh.cpp
+++ b/src/Core/Mesh/Mesh.cpp
@@ -1,31 +1,43 @@
 #include "Mesh.h"
 
 namespace CGEngine {
-	Mesh::Mesh(vector<GLfloat> vertices, vector<GLfloat> normals, V3f position, V3f rotation, V3f scale, Texture* texture, bool screenSpaceRendering, bool textureCoordinatesEnabled, vector<GLfloat> vertexColor) : position(position), eulerRotation(rotation), scale(scale), vertices(vertices), meshTexture(texture), textureCoordinatesEnabled(textureCoordinatesEnabled), screenSpaceRendering(screenSpaceRendering), vertexColor(vertexColor), normals(normals) { };
+	Mesh::Mesh(vector<GLfloat> vertices, vector<GLfloat> normals, V3f position, V3f rotation, V3f scale, Texture* texture, bool screenSpaceRendering, bool textureCoordinatesEnabled, vector<GLfloat> vertexColor, bool lightingEnabled, bool texture2dEnabled, bool normalsEnabled) : position(position), eulerRotation(rotation), scale(scale), vertices(vertices), meshTexture(texture), textureCoordinatesEnabled(textureCoordinatesEnabled), screenSpaceRendering(screenSpaceRendering), vertexColor(vertexColor), normals(normals), lightingEnabled(lightingEnabled), texture2dEnabled(texture2dEnabled), normalsEnabled(normalsEnabled) { };
 
 	void Mesh::render(Transform transform) {
 		if (renderer.setGLWindowState(true)) {
 			renderer.pullGL();
-			(void)meshTexture->generateMipmap();
-			Texture::bind(&(*meshTexture));
+			
+			//Generate mesh texture mips and binds
+			if (meshTexture != nullptr) {
+				(void)meshTexture->generateMipmap();
+				Texture::bind(&(*meshTexture));
+			} else {
+				Texture::bind(nullptr);
+			}
+			
+			//Size of vertex buffer determined by presence of texture coordinates
+			size_t vBufferSize = 3 + (textureCoordinatesEnabled ? 2 : 0);
+			//Apply vertex buffer to vertex pointer
+			glVertexPointer(3, GL_FLOAT, vBufferSize * sizeof(GLfloat), vertices.data());
 
-			// Enable vertex component
-			glVertexPointer(3, GL_FLOAT, 5 * sizeof(GLfloat), vertices.data());
-
-			//Enable texture coordinate component if enabled
+			//Apply vertex buffer to texture coordinate pointer
 			if (textureCoordinatesEnabled) {
-				glTexCoordPointer(2, GL_FLOAT, 5 * sizeof(GLfloat), vertices.data() + 3);
+				glTexCoordPointer(2, GL_FLOAT, vBufferSize * sizeof(GLfloat), vertices.data() + 3);
 			}
 
+			//Apply normals
+			if (normalsEnabled) {
+				glNormalPointer(GL_FLOAT, 0, normals.data());
+			}
+
+			//Apply vertex colors
 			if (vertexColor.size()>0) {
 				glColor3fv(vertexColor.data());
 			} else {
-				glColor3fv(vector<float>({1,1,1}).data());
+				const GLfloat white[] = {1,1,1,1};
+				glColor3fv(white);
 			}
-
-			glColorMaterial(GL_FRONT, GL_DIFFUSE);
-
-			glNormalPointer(GL_FLOAT, 0, normals.data());
+			glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE);
 
 			//Get world xy position, xy right, z rotation, and xy scale from Body transform
 			Vector2f worldPositionXY = world->getGlobalPosition(transform);
@@ -58,6 +70,20 @@ namespace CGEngine {
 			//Rotate by eulerRotation + SFML rotation on z
 			glRotatef(worldAngleZ_Deg + eulerRotation.z, 0, 0, 1);
 			glEnable(GL_NORMALIZE);
+
+			if (lightingEnabled && openGLSettings.lightingEnabled) {
+				glEnable(GL_LIGHTING);
+			} else {
+				glDisable(GL_LIGHTING);
+			}
+
+			if (texture2dEnabled &&  openGLSettings.texture2DEnabled) {
+				glEnable(GL_TEXTURE_2D);
+			}
+			else {
+				glDisable(GL_TEXTURE_2D);
+			}
+
 			// Draw the cube
 			glDrawArrays(GL_TRIANGLES, 0, (vertices.capacity() / 5));
 			renderer.commitGL();

--- a/src/Core/Mesh/Mesh.h
+++ b/src/Core/Mesh/Mesh.h
@@ -7,7 +7,7 @@
 namespace CGEngine {
 	class Mesh : public Transformable{
 	public:
-		Mesh(vector<GLfloat> vertices, vector<GLfloat> normals, V3f position = { 0,0,0 }, V3f rotation = { 0,0,0 }, V3f scale = { 0,0,0 }, Texture* texture = nullptr, bool screenSpaceRendering = false, bool textureCoordinatesEnabled = true, vector<GLfloat> vertexColor = {});
+		Mesh(vector<GLfloat> vertices, vector<GLfloat> normals, V3f position = { 0,0,0 }, V3f rotation = { 0,0,0 }, V3f scale = { 0,0,0 }, Texture* texture = nullptr, bool screenSpaceRendering = false, bool textureCoordinatesEnabled = true, vector<GLfloat> vertexColor = {}, bool lightingEnabled = true, bool texture2dEnabled = true, bool normalsEnabled = true);
 
 		void render(Transform parentTransform);
 		vector<GLfloat> vertices;
@@ -21,5 +21,8 @@ namespace CGEngine {
 	private:
 		bool textureCoordinatesEnabled = true;
 		bool screenSpaceRendering = false;
+		bool lightingEnabled = true;
+		bool texture2dEnabled = true;
+		bool normalsEnabled = true;
 	};
 }

--- a/src/Core/World/Renderer.cpp
+++ b/src/Core/World/Renderer.cpp
@@ -25,23 +25,6 @@ namespace CGEngine {
 		//Don't enable color array
 		//glEnableClientState(GL_COLOR_ARRAY);
 
-		//Enable color materials
-		glEnable(GL_COLOR_MATERIAL);
-
-		// Setup OPENGL lighting
-		if (openGLSettings.lightingEnabled) {
-			glEnable(GL_LIGHTING);
-		} else {
-			glDisable(GL_LIGHTING);
-		}
-
-		bool Texture2DEnabled = true;
-		if (openGLSettings.texture2DEnabled) {
-			glEnable(GL_TEXTURE_2D);
-		} else {
-			glDisable(GL_TEXTURE_2D);
-		}
-
 		// Setup OPENGL viewport within window
 		FloatRect viewport = openGLSettings.viewport;
 		GLsizei viewPositionX_px = viewport.position.x;


### PR DESCRIPTION
- Move some OpenGL function calls from renderer to Mesh to allow per-mesh enable/disable of normals and textures
- Fixed an error with vertex coloring that would cause it to be applied to all subsequent meshes