### PR TITLE
Move Mesh parameters to RenderParameters and Transformation3D

### DIFF
--- a/src/Core/Mesh/Mesh.cpp
+++ b/src/Core/Mesh/Mesh.cpp
@@ -1,7 +1,7 @@
 #include "Mesh.h"
 
 namespace CGEngine {
-	Mesh::Mesh(vector<GLfloat> vertices, vector<GLfloat> normals, V3f position, V3f rotation, V3f scale, Texture* texture, bool screenSpaceRendering, bool textureCoordinatesEnabled, vector<GLfloat> vertexColor, bool lightingEnabled, bool texture2dEnabled, bool normalsEnabled) : position(position), eulerRotation(rotation), scale(scale), vertices(vertices), meshTexture(texture), textureCoordinatesEnabled(textureCoordinatesEnabled), screenSpaceRendering(screenSpaceRendering), vertexColor(vertexColor), normals(normals), lightingEnabled(lightingEnabled), texture2dEnabled(texture2dEnabled), normalsEnabled(normalsEnabled) { };
+	Mesh::Mesh(VertexModel model, Transformation3D transformation, Texture* texture, Color vertexColor, RenderParameters renderParams) : model(model), transformation(transformation), meshTexture(texture), vertexColor(vertexColor), renderParameters(renderParams) { };
 
 	void Mesh::render(Transform transform) {
 		if (renderer.setGLWindowState(true)) {
@@ -16,27 +16,25 @@ namespace CGEngine {
 			}
 			
 			//Size of vertex buffer determined by presence of texture coordinates
-			size_t vBufferSize = 3 + (textureCoordinatesEnabled ? 2 : 0);
+			size_t vBufferSize = 3 + (renderParameters.textureCoordinatesEnabled ? 2 : 0);
 			//Apply vertex buffer to vertex pointer
-			glVertexPointer(3, GL_FLOAT, vBufferSize * sizeof(GLfloat), vertices.data());
+			glVertexPointer(3, GL_FLOAT, vBufferSize * sizeof(GLfloat), model.vertices.data());
 
 			//Apply vertex buffer to texture coordinate pointer
-			if (textureCoordinatesEnabled) {
-				glTexCoordPointer(2, GL_FLOAT, vBufferSize * sizeof(GLfloat), vertices.data() + 3);
+			if (renderParameters.textureCoordinatesEnabled) {
+				glTexCoordPointer(2, GL_FLOAT, vBufferSize * sizeof(GLfloat), model.vertices.data() + 3);
 			}
 
 			//Apply normals
-			if (normalsEnabled) {
-				glNormalPointer(GL_FLOAT, 0, normals.data());
+			if (renderParameters.normalsEnabled) {
+				glNormalPointer(GL_FLOAT, 0, model.normals.data());
 			}
 
 			//Apply vertex colors
-			if (vertexColor.size()>0) {
-				glColor3fv(vertexColor.data());
-			} else {
-				const GLfloat white[] = {1,1,1,1};
-				glColor3fv(white);
-			}
+			const GLfloat color[] = { vertexColor.r,vertexColor.g,vertexColor.b,vertexColor.a };
+			glColor3fv(color);
+			
+			//Apply lit material
 			glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE);
 
 			//Get world xy position, xy right, z rotation, and xy scale from Body transform
@@ -48,36 +46,36 @@ namespace CGEngine {
 			//Get the position of the window View
 			Vector2f viewPosition = screen->getCurrentView()->getTransform().transformPoint({ 0,0 });
 			//If Screen Space Rendering is enabled, unset viewPosition
-			if (screenSpaceRendering) {
+			if (renderParameters.screenSpaceRendering) {
 				viewPosition = { 0,0 };
 			}
 			//Calculate the offset by current View size
 			float viewScreenOffsetX = 2 / screen->getCurrentView()->getSize().x;
 			float viewScreenOffsetY = 2 / screen->getCurrentView()->getSize().y;
 			//Negate y position to match SFML y-axis orientation, add the view's position to convert from Screen Space, and offset by View size
-			Vector2f globalPositionXY = V2f({ (worldPositionXY.x + position.x) *viewScreenOffsetX,(-worldPositionXY.y - position.y) *viewScreenOffsetY}) + viewPosition;
+			Vector2f globalPositionXY = V2f({ (worldPositionXY.x + transformation.position.x) *viewScreenOffsetX,(-worldPositionXY.y - transformation.position.y) *viewScreenOffsetY}) + viewPosition;
 			
 			glMatrixMode(GL_MODELVIEW);
 			glLoadIdentity();
 			//Apply SFML global XY position to this Mesh's V3 position
-			glTranslatef(globalPositionXY.x, globalPositionXY.y, position.z);
+			glTranslatef(globalPositionXY.x, globalPositionXY.y, transformation.position.z);
 			//Scale by SFML scale on XY multiplied by Mesh's V3 scale
-			glScalef(worldScaleXY.x * scale.x, worldScaleXY.y * scale.y, scale.z);
+			glScalef(worldScaleXY.x * transformation.scale.x, worldScaleXY.y * transformation.scale.y, transformation.scale.z);
 			//Rotate by eulerRotation on x
-			glRotatef(eulerRotation.x, 1, 0, 0);
+			glRotatef(transformation.rotation.x, 1, 0, 0);
 			//Rotate by eulerRotation on y
-			glRotatef(eulerRotation.y, 0, 1, 0);
+			glRotatef(transformation.rotation.y, 0, 1, 0);
 			//Rotate by eulerRotation + SFML rotation on z
-			glRotatef(worldAngleZ_Deg + eulerRotation.z, 0, 0, 1);
+			glRotatef(worldAngleZ_Deg + transformation.rotation.z, 0, 0, 1);
 			glEnable(GL_NORMALIZE);
 
-			if (lightingEnabled && openGLSettings.lightingEnabled) {
+			if (renderParameters.lightingEnabled && openGLSettings.lightingEnabled) {
 				glEnable(GL_LIGHTING);
 			} else {
 				glDisable(GL_LIGHTING);
 			}
 
-			if (texture2dEnabled &&  openGLSettings.texture2DEnabled) {
+			if (renderParameters.texture2dEnabled &&  openGLSettings.texture2DEnabled) {
 				glEnable(GL_TEXTURE_2D);
 			}
 			else {
@@ -85,7 +83,7 @@ namespace CGEngine {
 			}
 
 			// Draw the cube
-			glDrawArrays(GL_TRIANGLES, 0, (vertices.capacity() / 5));
+			glDrawArrays(GL_TRIANGLES, 0, (model.vertices.capacity() / vBufferSize));
 			renderer.commitGL();
 		}
 	}

--- a/src/Core/Mesh/Mesh.h
+++ b/src/Core/Mesh/Mesh.h
@@ -5,23 +5,43 @@
 #include "../Engine/Engine.h"
 
 namespace CGEngine {
-	class Mesh : public Transformable{
-	public:
-		Mesh(vector<GLfloat> vertices, vector<GLfloat> normals, V3f position = { 0,0,0 }, V3f rotation = { 0,0,0 }, V3f scale = { 0,0,0 }, Texture* texture = nullptr, bool screenSpaceRendering = false, bool textureCoordinatesEnabled = true, vector<GLfloat> vertexColor = {}, bool lightingEnabled = true, bool texture2dEnabled = true, bool normalsEnabled = true);
+	struct RenderParameters {
+		RenderParameters(bool lighting = true, bool textures = true, bool screenSpace = false, bool normals = true, bool textureCoords = true) :lightingEnabled(lighting),texture2dEnabled(textures),screenSpaceRendering(screenSpace),normalsEnabled(normals), textureCoordinatesEnabled(textureCoords){};
 
-		void render(Transform parentTransform);
-		vector<GLfloat> vertices;
-		Texture* meshTexture;
-		V3f position = { 0,0,0 };
-		V3f eulerRotation = { 0,0,0 };
-		V3f scale = { 1,1,1 };
-		vector<GLfloat> vertexColor = { 1.f,1.f,1.f };
-		vector<GLfloat> normals;
-	private:
-		bool textureCoordinatesEnabled = true;
-		bool screenSpaceRendering = false;
 		bool lightingEnabled = true;
 		bool texture2dEnabled = true;
+		bool screenSpaceRendering = false;
 		bool normalsEnabled = true;
+		bool textureCoordinatesEnabled = true;
+	};
+
+	struct VertexModel {
+		VertexModel(vector<GLfloat> vertices, vector<GLfloat> normals = {}) :vertices(vertices), normals(normals) {};
+
+		vector<GLfloat> vertices;
+		vector<GLfloat> normals;
+	};
+
+	struct Transformation3D {
+		Transformation3D(Vector3f position = Vector3f()) :position(position), rotation(Vector3f()), scale(Vector3f()) { };
+		Transformation3D(Vector3f position, Vector3f rotation, Vector3f scale) :position(position), rotation(rotation), scale(scale) { };
+		Transformation3D(Vector3f position, Vector3f scale) :position(position), rotation(Vector3f()), scale(scale) { };
+
+		Vector3f position;
+		Vector3f rotation;
+		Vector3f scale;
+	};
+
+	class Mesh : public Transformable{
+	public:
+		Mesh(VertexModel model, Transformation3D transformation = Transformation3D(), Texture* texture = nullptr, Color vertexColor = {}, RenderParameters renderParams = RenderParameters());
+
+		void render(Transform parentTransform);
+		VertexModel model;
+		Texture* meshTexture;
+		Transformation3D transformation;
+		Color vertexColor = Color::White;
+	private:
+		RenderParameters renderParameters;
 	};
 }

--- a/src/Standard/Meshes/CommonVArrays.cpp
+++ b/src/Standard/Meshes/CommonVArrays.cpp
@@ -1,6 +1,14 @@
 #include "CommonVArrays.h"
 
 namespace CGEngine {
+    VertexModel getCubeModel(float scale) {
+        return VertexModel(getCubeVertices(scale), getCubeNormals());
+    }
+
+    VertexModel getPlaneModel(float scale) {
+        return VertexModel(getPlaneVertices(scale));
+    }
+
     vector<GLfloat> getCubeVertices(float scale) {
         return {
             // positions    // texture coordinates

--- a/src/Standard/Meshes/CommonVArrays.h
+++ b/src/Standard/Meshes/CommonVArrays.h
@@ -2,10 +2,13 @@
 
 #include "SFML/OpenGL.hpp"
 #include <vector>
+#include "../../Core/Mesh/Mesh.h"
 using namespace std;
 
 namespace CGEngine {
-	extern vector<GLfloat> getCubeVertices(float scale);
-	extern vector<GLfloat> getCubeNormals();
-	extern vector<GLfloat> getPlaneVertices(float scale);
+	extern VertexModel getCubeModel(float scale);
+	vector<GLfloat> getCubeVertices(float scale);
+	vector<GLfloat> getCubeNormals();
+	extern VertexModel getPlaneModel(float scale);
+	vector<GLfloat> getPlaneVertices(float scale);
 }


### PR DESCRIPTION
- Moves texturing, lighting, normals, screen space rendering and texture coordinate booleans to RenderParameters struct, moves position, eulerRotation, and scale to Transformation3D struct (with eulerRotation renamed to rotation), and moves vertices and normals to VertexMesh to ease Mesh construction
- Transformation3D can take a position and either a rotation or a scale or neither
- getCubeVertices, getCubeNormals, and getPlaneVertices were replaced with extern getCubeModel and getPlaneModel