### PR TITLE
F mlt shader programs

### DIFF
--- a/resources/shaders/StdFragShader.txt
+++ b/resources/shaders/StdFragShader.txt
@@ -1,0 +1,8 @@
+#version 330
+
+uniform sampler2D texture;
+varying vec2 uv;
+
+void main() {
+	gl_FragColor = texture2D(texture, uv);
+}

--- a/resources/shaders/StdVertexShader.txt
+++ b/resources/shaders/StdVertexShader.txt
@@ -2,10 +2,12 @@
 
 attribute vec3 position;
 attribute vec2 texCoord;
+uniform mat4 camera;
 uniform mat4 projection;
+uniform mat4 model;
 varying vec2 uv;
 
 void main() {
-	gl_Position = projection * vec4(position, 1.0);
+	gl_Position = projection * camera * model * vec4(position, 1.0);
 	uv = texCoord;
 }

--- a/resources/shaders/StdVertexShader.txt
+++ b/resources/shaders/StdVertexShader.txt
@@ -3,11 +3,10 @@
 attribute vec3 position;
 attribute vec2 texCoord;
 uniform mat4 camera;
-uniform mat4 projection;
 uniform mat4 model;
 varying vec2 uv;
 
 void main() {
-	gl_Position = projection * camera * model * vec4(position, 1.0);
+	gl_Position = camera * model * vec4(position, 1.0);
 	uv = texCoord;
 }

--- a/resources/shaders/StdVertexShader.txt
+++ b/resources/shaders/StdVertexShader.txt
@@ -1,0 +1,11 @@
+#version 330
+
+attribute vec3 position;
+attribute vec2 texCoord;
+uniform mat4 projection;
+varying vec2 uv;
+
+void main() {
+	gl_Position = projection * vec4(position, 1.0);
+	uv = texCoord;
+}

--- a/src/Core/Camera/Camera.cpp
+++ b/src/Core/Camera/Camera.cpp
@@ -1,46 +1,89 @@
 #include "Camera.h"
 #include "../Engine/Engine.h"
 namespace CGEngine {
-	Camera::Camera(Vector3f position, Vector3f rotation, float fov, float aspect, float nearPlane, float farPlane) : position(glm::vec3(position.x, position.y, position.z)), rotation(glm::vec3(rotation.x, rotation.y, rotation.z)), fov(fov), aspect(aspect), nearPlane(nearPlane), farPlane(farPlane) {
-		transform = glm::lookAt(this->position, this->position + this->rotation, glm::vec3(0, 1, 0));
-		projection = glm::perspective(glm::radians(fov), aspect, nearPlane, farPlane);
-	};
-	Camera::Camera(float fov, float aspect, float nearPlane, float farPlane) : Camera({ 0,0,0 }, { 0,0,-1 },fov,aspect, nearPlane,farPlane) { }
-	Camera::Camera(float aspect) : Camera({0,0,0}, {0,0,-1}, 50.f, aspect, 0.1f, 500.f) { }
+	static const float MaxVerticalCameraAngle = 85.0f; //must be less than 90 to avoid gimbal lock
+
+	Camera::Camera(Vector3f position, float angleX, float angleY, float angleZ, float fov, float aspect, float nearPlane, float farPlane) : position(glm::vec3(position.x, position.y, position.z)), angleX(angleX), angleY(angleY), angleZ(angleZ), fov(fov), aspect(aspect), nearPlane(nearPlane), farPlane(farPlane) { };
+	Camera::Camera(float fov, float aspect, float nearPlane, float farPlane) : Camera({ 0,0,1 }, 0.0f, 0.0f, 0.0f, fov, aspect, nearPlane, farPlane) { }
+	Camera::Camera(float aspect) : Camera({0,0,1}, 0.0f, 0.0f, 0.0f, 93.f, aspect, 0.01f, 100.f) { }
 
 	void Camera::setPosition(Vector3f pos, bool affect2DView) {
-		this->position = { -pos.x,pos.y,-pos.z };
+		this->position = { pos.x,pos.y,pos.z };
+
 		if (affect2DView) {
 			screen->setViewPosition({ pos.x,pos.y });
 		}
 	}
 
-	void Camera::setRotation(Vector3f rotation, bool affect2DView) {
-		this->rotation = { rotation.x,rotation.y,rotation.z };
-		if (affect2DView) {
-			screen->setViewEulerRotation(rotation.z);
-		}
-	}
-
 	void Camera::move(Vector3f delta, bool affect2DView) {
-		position = position + glm::vec3{-delta.x, delta.y, -delta.z};
+		position += glm::vec3{delta.x, delta.y, delta.z};
+
 		if (affect2DView) {
 			screen->moveView({ delta.x,delta.y });
 		}
 	}
 
-	void Camera::rotate(Vector3f euler, bool affect2DView) {
-		rotation = rotation + glm::vec3{ euler.x,euler.y,euler.z };
-		if (affect2DView) {
-			screen->rotateView(degrees(euler.z));
-		}
+	glm::mat4 Camera::getOrientation() const {
+		glm::mat4 orientation;
+		orientation = glm::rotate(glm::radians(angleZ), glm::vec3(0, 0, 1));
+		orientation *= glm::rotate(glm::radians(angleY), glm::vec3(0, 1, 0));
+		orientation *= glm::rotate(glm::radians(angleX), glm::vec3(1, 0, 0));
+		return orientation;
 	}
 
-	glm::mat4 Camera::orientation() const {
-		glm::mat4 orientation;
-		orientation = glm::rotate(orientation, rotation.x, glm::vec3(1, 0, 0));
-		orientation = glm::rotate(orientation, rotation.y, glm::vec3(0, 1, 0));
-		orientation = glm::rotate(orientation, rotation.z, glm::vec3(0, 0, 1));
-		return orientation;
+	void Camera::rotate(Vector3f euler, bool affect2DView) {
+		angleX += euler.x;
+		angleY += euler.y;
+		angleZ += euler.z;
+		normalizeAngles();
+	}
+
+	void Camera::lookAt(Vector3f position) {
+		glm::vec3 pos(position.x, position.y, position.z);
+		assert(pos != this->position);
+		glm::vec3 direction = glm::normalize(pos - this->position);
+		angleY = glm::radians(asinf(-direction.y));
+		angleX = -glm::radians(atan2f(-direction.x, -direction.z));
+		normalizeAngles();
+	}
+
+	glm::vec3 Camera::getForward() {
+		glm::vec4 fwd = glm::inverse(getOrientation()) * glm::vec4(0, 0, -1, 1);
+		return glm::vec3(fwd);
+	}
+	glm::vec3 Camera::getUp() {
+		glm::vec4 up = glm::inverse(getOrientation()) * glm::vec4(0, 1, 0, 1);
+		return glm::vec3(up);
+	}
+	glm::vec3 Camera::getRight() {
+		glm::vec4 rgt = glm::inverse(getOrientation()) * glm::vec4(1, 0, 0, 1);
+		return glm::vec3(rgt);
+	}
+
+	glm::mat4 Camera::getMatrix() const {
+		return getProjection() * getTransform();
+	}
+	glm::mat4 Camera::getProjection() const {
+		return glm::perspective(glm::radians(fov), aspect, nearPlane, farPlane);
+	}
+	glm::mat4 Camera::getTransform() const {
+		return getOrientation() * glm::translate(-position);
+	}
+
+	void Camera::normalizeAngles() {
+		angleY = fmodf(angleY, 360.0f);
+		//fmodf can return negative values, but this will make them all positive
+		if (angleY < 0.0f)
+			angleY += 360.0f;
+
+		angleZ = fmodf(angleZ, 360.0f);
+		if (angleZ < 0.0f)
+			angleZ += 360.0f;
+
+		if (angleX > MaxVerticalCameraAngle) {
+			angleX = MaxVerticalCameraAngle;
+		} else if (angleX < -MaxVerticalCameraAngle) {
+			angleX = -MaxVerticalCameraAngle;
+		}
 	}
 }

--- a/src/Core/Camera/Camera.cpp
+++ b/src/Core/Camera/Camera.cpp
@@ -1,39 +1,36 @@
 #include "Camera.h"
 #include "../Engine/Engine.h"
 namespace CGEngine {
-	Camera::Camera(Vector3f position, Vector3f rotation, float fov, float aspect, float near, float far) :position(position), eulerRotation(rotation), fov(fov), aspect(aspect), nearPlane(near), farPlane(far) {
-		projection = glm::perspective(fov, aspect, nearPlane, farPlane);
+	Camera::Camera(Vector3f position, Vector3f rotation, float fov, float aspect, float nearPlane, float farPlane) : position(glm::vec3(position.x, position.y, position.z)), rotation(glm::vec3(rotation.x, rotation.y, rotation.z)), fov(fov), aspect(aspect), nearPlane(nearPlane), farPlane(farPlane) {
+		transform = glm::lookAt(this->position, this->position + this->rotation, glm::vec3(0, 1, 0));
+		projection = glm::perspective(glm::radians(fov), aspect, nearPlane, farPlane);
 	};
-	Camera::Camera(float fov, float aspect, float near, float far) : position(Vector3f()), eulerRotation(Vector3f()), fov(fov), aspect(aspect), nearPlane(near), farPlane(far) {
-		projection = glm::perspective(fov, aspect, nearPlane, farPlane);
-	}
-	Camera::Camera(float aspect) : position(Vector3f()), eulerRotation(Vector3f()), fov(93.f), aspect(aspect), nearPlane(1.f), farPlane(500.f) {
-		projection = glm::perspective(fov, aspect, nearPlane, farPlane);
-	}
+	Camera::Camera(float fov, float aspect, float nearPlane, float farPlane) : Camera({ 0,0,0 }, { 0,0,-1 },fov,aspect, nearPlane,farPlane) { }
+	Camera::Camera(float aspect) : Camera({0,0,0}, {0,0,-1}, 50.f, aspect, 0.1f, 500.f) { }
 
 	void Camera::setPosition(Vector3f pos, bool affect2DView) {
-		position = { -pos.x,pos.y,-pos.z };
+		this->position = { -pos.x,pos.y,-pos.z };
 		if (affect2DView) {
 			screen->setViewPosition({ pos.x,pos.y });
 		}
 	}
 
 	void Camera::setRotation(Vector3f rotation, bool affect2DView) {
-		eulerRotation = rotation;
+		this->rotation = { rotation.x,rotation.y,rotation.z };
 		if (affect2DView) {
 			screen->setViewEulerRotation(rotation.z);
 		}
 	}
 
 	void Camera::move(Vector3f delta, bool affect2DView) {
-		position = position + Vector3f({-delta.x, delta.y, -delta.z});
+		position = position + glm::vec3{-delta.x, delta.y, -delta.z};
 		if (affect2DView) {
 			screen->moveView({ delta.x,delta.y });
 		}
 	}
 
 	void Camera::rotate(Vector3f euler, bool affect2DView) {
-		eulerRotation = eulerRotation + euler;
+		rotation = rotation + glm::vec3{ euler.x,euler.y,euler.z };
 		if (affect2DView) {
 			screen->rotateView(degrees(euler.z));
 		}
@@ -41,9 +38,9 @@ namespace CGEngine {
 
 	glm::mat4 Camera::orientation() const {
 		glm::mat4 orientation;
-		orientation = glm::rotate(orientation, eulerRotation.x, glm::vec3(1, 0, 0));
-		orientation = glm::rotate(orientation, eulerRotation.y, glm::vec3(0, 1, 0));
-		orientation = glm::rotate(orientation, eulerRotation.z, glm::vec3(0, 0, 1));
+		orientation = glm::rotate(orientation, rotation.x, glm::vec3(1, 0, 0));
+		orientation = glm::rotate(orientation, rotation.y, glm::vec3(0, 1, 0));
+		orientation = glm::rotate(orientation, rotation.z, glm::vec3(0, 0, 1));
 		return orientation;
 	}
 }

--- a/src/Core/Camera/Camera.h
+++ b/src/Core/Camera/Camera.h
@@ -10,30 +10,29 @@ using namespace sf;
 namespace CGEngine {
 	class Camera {
 	public:
-		Camera(Vector3f position, Vector3f target = {0,0,-1}, float fov = 93.f, float aspect = 1.f, float near = 1.f, float far = 500.f);
-		Camera(float fov, float aspect, float near = 1.f, float far = 500.f);
+		Camera(Vector3f position, float angleX = 0.0f, float angleY = 0.0f, float angleZ = 0.0f, float fov = 93.f, float aspect = 1.f, float near = 1.f, float far = 500.f);
+		Camera(float fov, float aspect, float near = 0.01f, float far = 100.f);
 		Camera(float aspect = 1.f);
 		void setPosition(Vector3f pos, bool affect2DView = true);
-		void setRotation(Vector3f rotation, bool affect2DView = true);
 		void move(Vector3f delta, bool affect2DView = true);
+		glm::mat4 getOrientation() const;
 		void rotate(Vector3f euler, bool affect2DView = true);
-		glm::mat4 getProjection() {
-			glm::mat4 proj = projection;// *orientation();
-			proj = glm::translate(proj, glm::vec3(position.x, position.y, position.z));
-			return proj;
-		}
-		glm::mat4 getTransform() {
-			return transform;
-		}
-		glm::mat4 Camera::orientation() const;
+		void lookAt(Vector3f position);
+		glm::vec3 getForward();
+		glm::vec3 getUp();
+		glm::vec3 getRight();
+		glm::mat4 getMatrix() const;
+		glm::mat4 getProjection() const;
+		glm::mat4 getTransform() const;
 	private:
 		glm::vec3 position = { 0,0,0 };
-		glm::vec3 rotation = { 0,0,-1 };
+		float angleX;
+		float angleY;
+		float angleZ;
 		float fov = 50.f;
 		float aspect = 1.f;
 		float nearPlane = 0.1f;
 		float farPlane = 500.0f;
-		glm::mat4 transform;
-		glm::mat4 projection;
+		void normalizeAngles();
 	};
 }

--- a/src/Core/Camera/Camera.h
+++ b/src/Core/Camera/Camera.h
@@ -10,7 +10,7 @@ using namespace sf;
 namespace CGEngine {
 	class Camera {
 	public:
-		Camera(Vector3f position, Vector3f rotation = Vector3f(), float fov = 93.f, float aspect = 1.f, float near = 1.f, float far = 500.f);
+		Camera(Vector3f position, Vector3f target = {0,0,-1}, float fov = 93.f, float aspect = 1.f, float near = 1.f, float far = 500.f);
 		Camera(float fov, float aspect, float near = 1.f, float far = 500.f);
 		Camera(float aspect = 1.f);
 		void setPosition(Vector3f pos, bool affect2DView = true);
@@ -19,17 +19,21 @@ namespace CGEngine {
 		void rotate(Vector3f euler, bool affect2DView = true);
 		glm::mat4 getProjection() {
 			glm::mat4 proj = projection;// *orientation();
-			proj = glm::translate(proj, -glm::vec3(position.x,position.y,position.z));
+			proj = glm::translate(proj, glm::vec3(position.x, position.y, position.z));
 			return proj;
+		}
+		glm::mat4 getTransform() {
+			return transform;
 		}
 		glm::mat4 Camera::orientation() const;
 	private:
-		Vector3f position;
-		Vector3f eulerRotation = { 0,0,0 };
-		float fov = 93.f;
+		glm::vec3 position = { 0,0,0 };
+		glm::vec3 rotation = { 0,0,-1 };
+		float fov = 50.f;
 		float aspect = 1.f;
-		float nearPlane = 1.f;
+		float nearPlane = 0.1f;
 		float farPlane = 500.0f;
+		glm::mat4 transform;
 		glm::mat4 projection;
 	};
 }

--- a/src/Core/Mesh/Mesh.cpp
+++ b/src/Core/Mesh/Mesh.cpp
@@ -7,7 +7,19 @@ namespace CGEngine {
 		renderer.pullGL();
 		bindTexture();
 		renderer.bufferMeshData(model);
-		renderer.renderMesh(model, transformation);
+
+		//Combine SFML entity transform components with 3D transformation components
+		Vector2f position2d = world->getGlobalPosition(transform);
+		Vector3f position = { position2d.x + transformation.position.x,position2d.y + transformation.position.y,transformation.position.z };
+
+		Angle rotation2d = world->getGlobalRotation(transform);
+		Vector3f rotation = { transformation.rotation.x,transformation.rotation.y, rotation2d.asDegrees()+transformation.rotation.z, };
+
+		Vector2f scale2d = world->getGlobalScale(transform);
+		Vector3f scale = { scale2d.x * transformation.scale.x,scale2d.y * transformation.scale.y, transformation.scale.z };
+		Transformation3D combinedTransformation = Transformation3D(position, rotation, scale);
+
+		renderer.renderMesh(model, combinedTransformation);
 		renderer.commitGL();
 	}
 
@@ -23,5 +35,28 @@ namespace CGEngine {
 			}
 		}
 		renderer.setGLWindowState(false);
+	}
+
+	void Mesh::setPosition(Vector3f pos) {
+		transformation.position = pos;
+	}
+	void Mesh::move(Vector3f delta) {
+		transformation.position += delta;
+	}
+
+	void Mesh::setRotation(Vector3f rot) {
+		transformation.rotation = rot;
+	}
+
+	void Mesh::rotate(Vector3f delta) {
+		transformation.rotation += delta;
+	}
+
+	void Mesh::setScale(Vector3f scale) {
+		transformation.scale = scale;
+	}
+
+	void Mesh::scale(Vector3f delta) {
+		transformation.scale += delta;
 	}
 }

--- a/src/Core/Mesh/Mesh.h
+++ b/src/Core/Mesh/Mesh.h
@@ -19,6 +19,12 @@ namespace CGEngine {
 
 		void render(Transform parentTransform);
 		void bindTexture();
+		void setPosition(Vector3f pos);
+		void move(Vector3f delta);
+		void setRotation(Vector3f rot);
+		void rotate(Vector3f delta);
+		void setScale(Vector3f scale);
+		void scale(Vector3f delta);
 	private:
 		VertexModel model;
 		Texture* meshTexture;

--- a/src/Core/Shader/Program.cpp
+++ b/src/Core/Shader/Program.cpp
@@ -1,0 +1,81 @@
+#include "Program.h"
+#include <stdexcept>
+
+namespace CGEngine {
+	Program::Program(const vector<Shader>& shaders) : objectId(0) {
+		if (shaders.size() <= 0) {
+			cout << "No shaders provided to program" << "\n";
+		}
+
+		objectId = glCreateProgram();
+		if (objectId == 0) {
+			cout << "glCreateProgram failed" << "\n";
+		}
+
+		for (unsigned i = 0; i < shaders.size(); ++i) {
+			glAttachShader(objectId, shaders[i].getObjectId());
+		}
+
+		glLinkProgram(objectId);
+
+		for (unsigned i = 0; i < shaders.size(); ++i) {
+			glDetachShader(objectId, shaders[i].getObjectId());
+		}
+
+		GLint status;
+		glGetProgramiv(objectId, GL_LINK_STATUS, &status);
+		if (status == GL_FALSE) {
+			string msg("Program failed to link shaders: ");
+
+			GLint infoLength;
+			glGetProgramiv(objectId, GL_INFO_LOG_LENGTH, &infoLength);
+			char* info = new char[infoLength + 1];
+			glGetProgramInfoLog(objectId, infoLength, NULL, info);
+			msg += info;
+			delete[] info;
+
+			glDeleteProgram(objectId);
+			objectId = 0;
+			cout << msg << "\n";
+		}
+	}
+
+	Program::Program(string vertexShaderPath, string fragmentShaderPath) : 
+		Program({ Shader::readFile(vertexShaderPath, GL_VERTEX_SHADER),Shader::readFile(fragmentShaderPath, GL_FRAGMENT_SHADER) }) { }
+
+	Program::~Program() {
+		if (objectId != 0) {
+			glDeleteProgram(objectId);
+		}
+	}
+
+	GLuint Program::getObjectId() const {
+		return objectId;
+	}
+
+	GLint Program::attrib(const GLchar* attribName) const {
+		if (!attribName) {
+			cout << "attribName was NULL" << "\n";
+		}
+
+		GLint attrib = glGetAttribLocation(objectId, attribName);
+		if (attrib == -1) {
+			cout << "Program attribute not found: " << attribName << "\n";
+		}
+
+		return attrib;
+	}
+
+	GLint Program::uniform(const GLchar* uniformName) const {
+		if (!uniformName) {
+			cout << "uniformName was NULL" << "\n";
+		}
+
+		GLint uniform = glGetUniformLocation(objectId, uniformName);
+		if (uniform == -1) {
+			cout << "Program uniform not found: " << uniformName << "\n";
+		}
+
+		return uniform;
+	}
+}

--- a/src/Core/Shader/Program.cpp
+++ b/src/Core/Shader/Program.cpp
@@ -78,4 +78,19 @@ namespace CGEngine {
 
 		return uniform;
 	}
+
+	void Program::use() {
+		glUseProgram(getObjectId());
+	}
+
+	void Program::stop() {
+		assert(inUse());
+		glUseProgram(0);
+	}
+
+	GLint Program::inUse() {
+		GLint currentProgram = 0;
+		glGetIntegerv(GL_CURRENT_PROGRAM, &currentProgram);
+		return currentProgram;
+	}
 }

--- a/src/Core/Shader/Program.cpp
+++ b/src/Core/Shader/Program.cpp
@@ -84,7 +84,6 @@ namespace CGEngine {
 	}
 
 	void Program::stop() {
-		assert(inUse());
 		glUseProgram(0);
 	}
 

--- a/src/Core/Shader/Program.h
+++ b/src/Core/Shader/Program.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "Shader.h"
+#include <vector>
+#include <glm.hpp>
+#include <gtc/type_ptr.hpp>
+
+namespace CGEngine {
+	class Program {
+	public:
+		Program(const vector<Shader>& shaders);
+		Program(string vertexShader, string fragmentShader);
+		~Program();
+		GLuint getObjectId() const;
+		GLint attrib(const GLchar* attribName) const;
+		GLint uniform(const GLchar* uniformName) const;
+
+		void setAttrib(const GLchar* attribName, GLfloat v0) {
+			glVertexAttrib1f(attrib(attribName), v0);
+		}
+		void setAttrib(const GLchar* attribName, GLfloat* v0) {
+			glVertexAttrib1fv(attrib(attribName), v0);
+		}
+		void setAttrib(const GLchar* attribName, GLint v0) {
+			glVertexAttribI1i(attrib(attribName), v0);
+		}
+		void setAttrib(const GLchar* attribName, GLint* v0) {
+			glVertexAttribI1iv(attrib(attribName), v0);
+		}
+		void setUniform(const GLchar* name, GLfloat v0) {
+			glUniform1f(uniform(name), v0);
+		}
+		void setUniform(const GLchar* name, GLint v0) {
+			glUniform1i(uniform(name), v0);
+		}
+		void setUniform(const GLchar* name, GLfloat v0, GLfloat v1) {
+			glUniform2f(uniform(name), v0, v1);
+		}
+		void setUniform(const GLchar* name, GLint v0, GLint v1) {
+			glUniform2i(uniform(name), v0, v1);
+		}
+		void setUniform(const GLchar* name, GLfloat v0, GLfloat v1, GLfloat v2) {
+			glUniform3f(uniform(name), v0, v1, v2);
+		}
+		void setUniform(const GLchar* name, GLint v0, GLint v1, GLint v2) {
+			glUniform3i(uniform(name), v0, v1, v2);
+		}
+		void setUniform(const GLchar* name, GLfloat v0, GLfloat v1, GLfloat v2 , GLfloat v3) {
+			glUniform4f(uniform(name), v0, v1, v2, v3);
+		}
+		void setUniform(const GLchar* name, GLint v0, GLint v1, GLint v2, GLint v3) {
+			glUniform4i(uniform(name), v0, v1, v2, v3);
+		}
+		void setUniform(const GLchar* name, glm::mat2& m, GLboolean transpose = GL_FALSE) {
+			glUniformMatrix2fv(uniform(name), 1, transpose, glm::value_ptr(m));
+		}
+		void setUniform(const GLchar* name, glm::mat3& m, GLboolean transpose = GL_FALSE) {
+			glUniformMatrix3fv(uniform(name), 1, transpose, glm::value_ptr(m));
+		}
+		void setUniform(const GLchar* name, glm::mat4& m, GLboolean transpose = GL_FALSE) {
+			glUniformMatrix4fv(uniform(name), 1, transpose, glm::value_ptr(m));
+		}
+	private:
+		GLuint objectId;
+
+		Program(const Program&);
+		const Program& operator=(const Program&);
+	};
+}

--- a/src/Core/Shader/Program.h
+++ b/src/Core/Shader/Program.h
@@ -60,6 +60,9 @@ namespace CGEngine {
 		void setUniform(const GLchar* name, glm::mat4& m, GLboolean transpose = GL_FALSE) {
 			glUniformMatrix4fv(uniform(name), 1, transpose, glm::value_ptr(m));
 		}
+		void use();
+		void stop();
+		GLint inUse();
 	private:
 		GLuint objectId;
 

--- a/src/Core/Shader/Shader.cpp
+++ b/src/Core/Shader/Shader.cpp
@@ -1,0 +1,90 @@
+#include "Shader.h"
+#include <fstream>
+#include <sstream>
+#include <cassert>
+namespace CGEngine {
+	Shader::Shader(const string& shaderCode, GLenum shaderType) : objectId(0), refCount(NULL) {
+		objectId = glCreateShader(shaderType);
+		if (objectId == 0) {
+			cout << "glCreateShader failed" << "\n";
+		}
+
+		const char* code = shaderCode.c_str();
+		glShaderSource(objectId, 1, (const GLchar**)&code, NULL);
+
+		//compile
+		glCompileShader(objectId);
+
+		GLint status;
+		glGetShaderiv(objectId, GL_COMPILE_STATUS, &status);
+		if (status == GL_FALSE) {
+			string msg("Shader failed to compile:\n");
+
+			GLint infoLength;
+			glGetShaderiv(objectId, GL_INFO_LOG_LENGTH, &infoLength);
+			char* info = new char[infoLength + 1];
+			glGetShaderInfoLog(objectId, infoLength, NULL, info);
+			msg += info;
+			delete[] info;
+
+			glDeleteShader(objectId);
+			objectId = 0;
+			cout << msg << "\n";
+		}
+
+		refCount = new unsigned;
+		*refCount = 1;
+	}
+
+	Shader::Shader(const Shader& other) : objectId(other.objectId), refCount(other.refCount) {
+		retain();
+	}
+
+	Shader::~Shader() {
+		if (refCount) {
+			release();
+		}
+	}
+
+	GLuint Shader::getObjectId() const {
+		return objectId;
+	}
+
+	Shader& Shader::operator=(const Shader& other) {
+		release();
+		objectId = other.objectId;
+		refCount = other.refCount;
+		retain();
+		return *this;
+	}
+
+	Shader Shader::readFile(const string& filePath, GLenum shaderType) {
+		ifstream f;
+		f.open(filePath.c_str(), ios::in | ios::binary);
+		if (!f.is_open()) {
+			cout << "Failed to open shader file: " << filePath << "\n";
+		}
+
+		stringstream buffer;
+		buffer << f.rdbuf();
+
+		Shader shader(buffer.str(), shaderType);
+		return shader;
+	}
+
+	void Shader::retain() {
+		assert(refCount);
+		*refCount += 1;
+	}
+
+	void Shader::release() {
+		assert(refCount && *refCount > 0);
+		*refCount -= 1;
+		if (*refCount == 0) {
+			glDeleteShader(objectId);
+			objectId = 0;
+			delete refCount;
+			refCount = NULL;
+		}
+	}
+}

--- a/src/Core/Shader/Shader.h
+++ b/src/Core/Shader/Shader.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <GL/glew.h>
+#include <string>
+#include <iostream>
+
+using namespace std;
+
+namespace CGEngine {
+	class Shader {
+    public:
+		static Shader readFile(const string& filePath, GLenum shaderType);
+        Shader(const string& shaderCode, GLenum shaderType);
+
+        GLuint getObjectId() const;
+
+        Shader(const Shader& other);
+        Shader& operator =(const Shader& other);
+        ~Shader();
+    private:
+        GLuint objectId;
+        unsigned* refCount;
+
+        void retain();
+        void release();
+	};
+}

--- a/src/Core/Types/Types.h
+++ b/src/Core/Types/Types.h
@@ -121,9 +121,9 @@ namespace CGEngine {
     };
 
     struct Transformation3D {
-        Transformation3D(Vector3f position = Vector3f()) :position(position), rotation(Vector3f()), scale(Vector3f()) { };
+        Transformation3D(Vector3f position = Vector3f()) :position(position), rotation(Vector3f()), scale({1,1,1}) { };
         Transformation3D(Vector3f position, Vector3f rotation, Vector3f scale) :position(position), rotation(rotation), scale(scale) { };
-        Transformation3D(Vector3f position, Vector3f scale) :position(position), rotation(Vector3f()), scale(scale) { };
+        Transformation3D(Vector3f position, Vector3f scale) :position(position), rotation(Vector3f()), scale({ 1,1,1 }) { };
 
         Vector3f position;
         Vector3f rotation;

--- a/src/Core/World/Renderer.h
+++ b/src/Core/World/Renderer.h
@@ -8,40 +8,14 @@
 #include "SFML/OpenGL.hpp"
 #include <vector>
 #include <map>
+#include <string>
 #include "../Body/Body.h"
 #include "../Camera/Camera.h"
+#include "../Shader/Shader.h"
+#include "../Shader/Program.h"
 using namespace std;
 
 namespace CGEngine {
-	///Shader Types
-	enum class ShaderType { Vertex, Fragment, Geometry, Count };
-	///Standard Uniforms in the shader.
-	enum class UniformType { TransformPVM, Count };
-	///Vertex attributes for shaders and the input vertex array.
-	enum class VertexAttribute { Position, TexCoord, COUNT };
-	///Basic vertex shader that transforms the vertex position based on a projection view matrix and passes the texture coordinate to the fragment shader.
-	const string defaultVertexShader =
-		"#version 330\n"\
-		"attribute vec3 position;"\
-		"attribute vec2 texCoord;" \
-		"uniform mat4 pvm;" \
-
-		"varying vec2 uv;" \
-
-		"void main() {"\
-		"	gl_Position = pvm * vec4(position, 1.0);"\
-		"	uv = texCoord;"\
-		"}";
-
-	///Basic fragment shader that returns the colour of a pixel based on the input texture and its coordinate.
-	const string defaultFragShader =
-		"#version 330\n" \
-		"uniform sampler2D texture;" \
-		"varying vec2 uv;" \
-
-		"void main() {" \
-		"	gl_FragColor = texture2D(texture, uv);" \
-		"}";
 	/// <summary>
 	/// Responsible for ordering Bodies for rendering. Allows for default ordering (children render on top of parents)
 	/// modified with per-object Z-Order
@@ -121,20 +95,10 @@ namespace CGEngine {
 		
 		GLenum initGlew();
 
-		///Shader Program
-		GLuint program = 0;
-		///List of shaders set up for a 3D scene.
-		GLuint shader[static_cast<unsigned int>(ShaderType::Count)];
-		///List of uniforms that can be defined values for the shader.
-		GLint uniform[static_cast<unsigned int>(UniformType::Count)];
-		//Shader functions
-		void loadFromMemory(const string& shaderData, ShaderType type);
-		GLuint buildShader(const string& l_src, unsigned int l_type);
-		void checkError(GLuint l_shader, GLuint l_flag, bool l_program, const string& l_errorMsg);
-
 		//Vertex Array and Buffer and Index Buffer
 		GLuint vao = 0;
 		GLuint vertexVBO = 0;
 		GLuint indexVBO = 0;
+		Program* program;
 	};
 }

--- a/src/Core/World/World.cpp
+++ b/src/Core/World/World.cpp
@@ -517,6 +517,7 @@ namespace CGEngine {
     }
 
     V2f World::getGlobalScale(Transform transform) const {
+        Transform r_wT = transform.rotate(getInverseGlobalRotation(transform));
         Vector2f wPos = transform.transformPoint({ 0,0 });
         Vector2f rPos = transform.transformPoint({ 1,1 });
         Vector2f dir = (rPos - wPos);

--- a/src/Standard/Meshes/CommonVArrays.cpp
+++ b/src/Standard/Meshes/CommonVArrays.cpp
@@ -13,69 +13,58 @@ namespace CGEngine {
     vector<float> getCubeVertices(float scale) {
         return {
             // positions   // texture coordinates
-           //front
-           -scale, -scale, -scale,  0, 0,
-            scale, -scale, -scale,  1, 0,
-            scale,  scale, -scale,  1, 1,
-           -scale,  scale, -scale,  0, 1,
-           //right
-            scale,  scale, -scale,  1, 1,
-            scale,  scale,  scale,  0, 1,
-            scale, -scale,  scale,  0, 0,
-            scale, -scale, -scale,  1, 0,
-            //back
-            -scale, -scale,  scale,  0, 0,
-             scale, -scale,  scale,  1, 0,
-             scale,  scale,  scale,  1, 1,
-            -scale,  scale,  scale,  0, 1,
-            //left
-            -scale, -scale,  scale,  0, 0,
-            -scale, -scale, -scale,  1, 0,
-            -scale,  scale, -scale,  1, 1,
-            -scale,  scale,  scale,  0, 1,
-            //upper
-             scale, -scale,  scale,  0, 1,
-            -scale, -scale,  scale,  1, 1,
-            -scale, -scale, -scale,  1, 0,
-             scale, -scale, -scale,  0, 0,
-             //bottom
-             -scale,  scale, -scale,  0, 1,
-              scale,  scale, -scale,  1, 1,
-              scale,  scale,  scale,  1, 0,
-             -scale,  scale,  scale,  0, 0,
+            //bottom
+            -scale,-scale,-scale,   0.0f, 0.0f,
+             scale,-scale,-scale,   1.0f, 0.0f,
+            -scale,-scale, scale,   0.0f, 1.0f,
+             scale,-scale,-scale,   1.0f, 0.0f,
+             scale,-scale, scale,   1.0f, 1.0f,
+            -scale,-scale, scale,   0.0f, 1.0f,
+
+            // top
+            -scale, scale,-scale,   0.0f, 0.0f,
+            -scale, scale, scale,   0.0f, 1.0f,
+             scale, scale,-scale,   1.0f, 0.0f,
+             scale, scale,-scale,   1.0f, 0.0f,
+            -scale, scale, scale,   0.0f, 1.0f,
+             scale, scale, scale,   1.0f, 1.0f,
+
+             // front
+             -scale,-scale, scale,   1.0f, 0.0f,
+              scale,-scale, scale,   0.0f, 0.0f,
+             -scale, scale, scale,   1.0f, 1.0f,
+              scale,-scale, scale,   0.0f, 0.0f,
+              scale, scale, scale,   0.0f, 1.0f,
+             -scale, scale, scale,   1.0f, 1.0f,
+
+             // back
+             -scale,-scale,-scale,   0.0f, 0.0f,
+             -scale, scale,-scale,   0.0f, 1.0f,
+              scale,-scale,-scale,   1.0f, 0.0f,
+              scale,-scale,-scale,   1.0f, 0.0f,
+             -scale, scale,-scale,   0.0f, 1.0f,
+              scale, scale,-scale,   1.0f, 1.0f,
+
+              // left
+              -scale,-scale, scale,   0.0f, 1.0f,
+              -scale, scale,-scale,   1.0f, 0.0f,
+              -scale,-scale,-scale,   0.0f, 0.0f,
+              -scale,-scale, scale,   0.0f, 1.0f,
+              -scale, scale, scale,   1.0f, 1.0f,
+              -scale, scale,-scale,   1.0f, 0.0f,
+
+              // right
+               scale,-scale, scale,   1.0f, 1.0f,
+               scale,-scale,-scale,   1.0f, 0.0f,
+               scale, scale,-scale,   0.0f, 0.0f,
+               scale,-scale, scale,   1.0f, 1.0f,
+               scale, scale,-scale,   0.0f, 0.0f,
+               scale, scale, scale,   0.0f, 1.0f
         };
     }
 
     vector<float> getCubeNormals() {
         return {
-            0,0,-1,
-            0,0,-1,
-            0,0,-1,
-            0,0,-1,
-            0,0,-1,
-            0,0,-1,
-
-            1,0,0,
-            1,0,0,
-            1,0,0,
-            1,0,0,
-            1,0,0,
-            1,0,0,
-
-            0,0,1,
-            0,0,1,
-            0,0,1,
-            0,0,1,
-            0,0,1,
-            0,0,1,
-
-            -1,0,0,
-            -1,0,0,
-            -1,0,0,
-            -1,0,0,
-            -1,0,0,
-            -1,0,0,
-
             0,-1,0,
             0,-1,0,
             0,-1,0,
@@ -88,7 +77,35 @@ namespace CGEngine {
             0,1,0,
             0,1,0,
             0,1,0,
-            0,1,0
+            0,1,0,
+
+            0,0,1,
+            0,0,1,
+            0,0,1,
+            0,0,1,
+            0,0,1,
+            0,0,1,
+
+            0,0,-1,
+            0,0,-1,
+            0,0,-1,
+            0,0,-1,
+            0,0,-1,
+            0,0,-1,
+
+            -1,0,0,
+            -1,0,0,
+            -1,0,0,
+            -1,0,0,
+            -1,0,0,
+            -1,0,0,
+
+            1,0,0,
+            1,0,0,
+            1,0,0,
+            1,0,0,
+            1,0,0,
+            1,0,0
         };
     }
 


### PR DESCRIPTION
- Removes use of index buffer for rendering meshes, relies on proper vertex setup
- Implements Shader Programs for OGL 3.2
- Implements OGL 3.2 perspective camera
- Implements proper OGL 3.2 Mesh and Camera projection
- Fixes a regression in world.getGlobalScale
- Fixes cube model vertex positions