### PR TITLE
Implement MaterialParameters map & Material shaders

### DIFF
--- a/src/Core/Material/Material.cpp
+++ b/src/Core/Material/Material.cpp
@@ -2,7 +2,51 @@
 #include "Material.h"
 
 namespace CGEngine {
-	Material::Material(MaterialParameters params) : diffuseTexturePath(params.diffuseTexturePath), diffuseTexture(textures->load(params.diffuseTexturePath)), diffuseTextureUVScale(params.diffuseTextureUVScale), diffuseColor(params.diffuseColor), shininess(params.shininess), opacity(params.opacity), specularColor(params.specularColor), gammaCorrected(params.gammaCorrected) {
+	Material::Material(ShaderProgramPath shaderPath) {
+		//TODO: Should materials using the same two shaders also use the same shader ref?
+		if (renderer.setGLWindowState(true)) {
+			shaderProgram = new Program(shaderPath);
+			renderer.setGLWindowState(false);
+		}
+
 		materialId = world->addMaterial(this);
+	}
+	Material::Material(SurfaceParameters params, ShaderProgramPath shaderPath) : Material(shaderPath) {
+		setParameter("diffuseTexturePath", params.diffuseTexturePath, ParamType::String);
+		setParameter("diffuseTextureUVScale", params.diffuseTextureUVScale, ParamType::V2);
+		setParameter("diffuseTexture", textures->load(params.diffuseTexturePath), ParamType::Texture2D);
+		setParameter("smoothnessFactor", params.smoothnessFactor, ParamType::Float);
+		setParameter("opacity", params.opacity, ParamType::Float);
+		setParameter("specularColor", params.specularColor, ParamType::RGBA);
+		setParameter("diffuseColor", params.diffuseColor, ParamType::RGBA);
+		setParameter("gammaCorrected", params.gammaCorrected, ParamType::Bool);
 	};
+
+	Material::Material(map<string, ParamData> materialParameters, ShaderProgramPath shaderPath) : Material(shaderPath) {
+		this->materialParameters = materialParameters;
+	}
+
+	void Material::setParameter(string paramName, any paramValue, ParamType paramType) {
+		materialParameters[paramName] = ParamData(paramValue, paramType);
+	}
+
+	optional<ParamData> Material::getParameter(string paramName) {
+		auto iterator = materialParameters.find(paramName);
+		if (iterator != materialParameters.end()) {
+			return (*iterator).second;
+		}
+		cout << "Material parameter " << paramName << " with not found";
+		return nullopt;
+	}
+
+	void Material::removeParameter(string paramName) {
+		auto iterator = materialParameters.find(paramName);
+		if (iterator != materialParameters.end()) {
+			materialParameters.erase(paramName);
+		}
+	}
+
+	Program* Material::getProgram() {
+		return shaderProgram;
+	}
 }

--- a/src/Core/Material/Material.h
+++ b/src/Core/Material/Material.h
@@ -1,34 +1,56 @@
 #pragma once
 
+#include <any>
+#include <optional>
 #include "SFML/Graphics.hpp"
 using namespace sf;
 using namespace std;
 
 namespace CGEngine {
-	struct MaterialParameters {
-		MaterialParameters(string diffuseTexturePath = "", Vector2f diffuseTextureUVScale = {1,1}, Color diffuseColor = Color::White, float shininess = 32.f, float opacity = 1.0f, Color specularColor = Color::White, bool gammaCorrected = false) : diffuseTexturePath(diffuseTexturePath), diffuseTextureUVScale(diffuseTextureUVScale), diffuseColor(diffuseColor), shininess(shininess), opacity(opacity), specularColor(specularColor), gammaCorrected(gammaCorrected) {};
+	struct SurfaceParameters {
+		SurfaceParameters(string diffuseTexturePath = "", Vector2f diffuseTextureUVScale = {1,1}, Color diffuseColor = Color::White, float smoothnessFactor = 32.f, float opacity = 1.0f, Color specularColor = Color::White, bool gammaCorrected = false) : diffuseTexturePath(diffuseTexturePath), diffuseTextureUVScale(diffuseTextureUVScale), diffuseColor(diffuseColor), smoothnessFactor(smoothnessFactor), opacity(opacity), specularColor(specularColor), gammaCorrected(gammaCorrected) {
+			params["diffuseTexturePath"] = diffuseTexturePath;
+			params["diffuseTextureUVScale"] = diffuseTextureUVScale;
+			params["smoothnessFactor"] = smoothnessFactor;
+			params["opacity"] = opacity;
+			params["specularColor"] = specularColor;
+			params["diffuseColor"] = diffuseColor;
+			params["gammaCorrected"] = gammaCorrected;
+		};
 		
 		string diffuseTexturePath;
 		Vector2f diffuseTextureUVScale = { 1,1 };
-		float shininess = 1.0f;
+		float smoothnessFactor = 1.0f;
 		float opacity = 0.0f;
 		Color specularColor = Color::White;
 		Color diffuseColor = Color::White;
 		bool gammaCorrected = false;
+		map<string, any> params;
 	};
 	class Material {
 	public:
-		Material(MaterialParameters params = MaterialParameters());
+		Material(ShaderProgramPath shaderPath = ShaderProgramPath());
+		Material(SurfaceParameters params, ShaderProgramPath shaderPath = ShaderProgramPath());
+		Material(map<string, ParamData> materialParameters, ShaderProgramPath shaderPath = ShaderProgramPath());
 
+		template<typename T>
+		optional<T> getParameter(string paramName) {
+			auto iterator = materialParameters.find(paramName);
+			if (iterator != materialParameters.end()) {
+				return any_cast<T>((*iterator).second.data);
+			}
+			cout << "Material parameter " << paramName << " not found";
+			return nullopt;
+		}
 
-		string diffuseTexturePath;
-		Texture* diffuseTexture;
-		Vector2f diffuseTextureUVScale = { 1,1 };
-		float shininess = 1.0f;
-		float opacity = 0.0f;
-		Color specularColor = Color::White;
-		Color diffuseColor = Color::White;
-		bool gammaCorrected = false;
+		optional<ParamData> getParameter(string paramName);
+		void setParameter(string paramName, any paramValue, ParamType paramType);
+		void removeParameter(string paramName);
+		Program* getProgram();
 		id_t materialId;
+	private:
+		friend class Renderer;
+		map<string, ParamData> materialParameters;
+		Program* shaderProgram = nullptr;
 	};
 }

--- a/src/Core/Mesh/Mesh.cpp
+++ b/src/Core/Mesh/Mesh.cpp
@@ -1,7 +1,11 @@
 #include "Mesh.h"
 
 namespace CGEngine {
-	Mesh::Mesh(VertexModel model, Transformation3D transformation, Material* material, RenderParameters renderParams, ShaderProgramPath shaderPath) : model(model), transformation(transformation), meshTexture(material->diffuseTexture), renderParameters(renderParams), shaderPath(shaderPath), material(material) {
+	Mesh::Mesh(VertexModel model, Transformation3D transformation, Material* material, RenderParameters renderParams) : model(model), transformation(transformation), renderParameters(renderParams), material(material) {
+		optional<Texture*> tex = material->getParameter<Texture*>("diffuseTexture");
+		if (tex.has_value()) {
+			meshTexture = tex.value();
+		}
 		renderer.getModelData(this);
 	};
 
@@ -67,10 +71,6 @@ namespace CGEngine {
 
 	void Mesh::scale(Vector3f delta) {
 		transformation.scale += delta;
-	}
-
-	ShaderProgramPath Mesh::getShaderProgramPaths() {
-		return shaderPath;
 	}
 
 	Material* Mesh::getMaterial() {

--- a/src/Core/Mesh/Mesh.h
+++ b/src/Core/Mesh/Mesh.h
@@ -16,7 +16,7 @@ namespace CGEngine {
 
 	class Mesh : public Transformable{
 	public:
-		Mesh(VertexModel model, Transformation3D transformation = Transformation3D(), Material* material = new Material(), RenderParameters renderParams = RenderParameters(), ShaderProgramPath shaderPath = ShaderProgramPath());
+		Mesh(VertexModel model, Transformation3D transformation = Transformation3D(), Material* material = new Material(), RenderParameters renderParams = RenderParameters());
 
 		void render(Transform parentTransform);
 		void bindTexture();
@@ -28,15 +28,13 @@ namespace CGEngine {
 		void scale(Vector3f delta);
 		void setModelData(ModelData data);
 		VertexModel getModel();
-		ShaderProgramPath getShaderProgramPaths();
 		Material* getMaterial();
 	private:
 		VertexModel model;
 		ModelData modelData;
-		Texture* meshTexture;
+		Texture* meshTexture = nullptr;
 		Transformation3D transformation;
 		RenderParameters renderParameters;
-		ShaderProgramPath shaderPath;
 		Material* material;
 	};
 }

--- a/src/Core/Types/Types.h
+++ b/src/Core/Types/Types.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "SFML/Graphics.hpp"
+#include <any>
 using namespace sf;
 using namespace std;
 
@@ -126,5 +127,13 @@ namespace CGEngine {
         Vector3f position;
         Vector3f rotation;
         Vector3f scale;
+    };
+
+    enum ParamType { NA, Bool, Int, Float, V2, V3, RGBA, String, Texture2D };
+
+    struct ParamData {
+        ParamData(any data = 0, ParamType type = ParamType::NA) : data(data), type(type) {};
+        any data;
+        ParamType type;
     };
 }

--- a/src/Core/World/Renderer.h
+++ b/src/Core/World/Renderer.h
@@ -16,6 +16,7 @@
 #include "../Light/Light.h"
 #include "../Material/Material.h"
 using namespace std;
+using namespace sf;
 
 namespace CGEngine {
 	class Mesh;
@@ -89,6 +90,10 @@ namespace CGEngine {
 		void removeLight(id_t lightId);
 		Light* getLight(id_t lightId);
 		string getUniformArrayPropertyName(string arrayName, int index, string propertyName);
+		string getUniformObjectPropertyName(string objectName, string propertyName);
+		glm::vec2 toGlm(Vector2f v);
+		glm::vec3 toGlm(Vector3f v);
+		glm::vec3 toGlm(Color c);
 	private:
 		friend class World;
 		RenderWindow* window = nullptr;

--- a/src/Core/World/World.cpp
+++ b/src/Core/World/World.cpp
@@ -534,7 +534,15 @@ namespace CGEngine {
         return materials.get(materialId);
     }
 
-    id_t World::createMaterial(MaterialParameters params) {
-        return materials.add(new Material(params));
+    id_t World::createMaterial(SurfaceParameters params, ShaderProgramPath shaderPath) {
+        return materials.add(new Material(params, shaderPath));
     }
+
+    id_t World::createMaterial(ShaderProgramPath shaderPath) {
+        return materials.add(new Material(shaderPath));
+    }
+    id_t World::createMaterial(map<string, ParamData> materialParams, ShaderProgramPath shaderPath) {
+        return materials.add(new Material(materialParams, shaderPath));
+    }
+
 }

--- a/src/Core/World/World.h
+++ b/src/Core/World/World.h
@@ -104,7 +104,9 @@ namespace CGEngine {
         /// <returns>The Body's rotation in world space as a normalized direction vector</returns>
         V2f getRight(Transform transform) const;
 
-        id_t createMaterial(MaterialParameters params);
+        id_t createMaterial(ShaderProgramPath shaderPath = ShaderProgramPath());
+        id_t createMaterial(SurfaceParameters params, ShaderProgramPath shaderPath = ShaderProgramPath());
+        id_t createMaterial(map<string,ParamData> materialParams, ShaderProgramPath shaderPath = ShaderProgramPath());
         id_t addMaterial(Material* material);
         Material* getMaterial(id_t materialId);
     private:


### PR DESCRIPTION
- Removes static Material surface parameters, replaces them with MaterialParameters map in Materials that can be given named parameters that are input into the shader automatically
- Moves shader ownership and management to Material because the MaterialParameters become the shader input