### PR TITLE
Optional textures, spec, opacity textures, gamma, lit toggle

### DIFF
--- a/resources/shaders/StdFragShader.txt
+++ b/resources/shaders/StdFragShader.txt
@@ -19,12 +19,22 @@ uniform int lightCount;
 
 uniform struct Material {
     vec3 diffuseColor;
+    bool useDiffuseTexture;
     sampler2D diffuseTexture;
     vec2 diffuseTextureUVScale;
+    bool useSpecularTexture;
+    sampler2D specularTexture;
+    vec2 specularTextureUVScale;
     vec3 specularColor;
     float smoothnessFactor;
+    bool useOpacityTexture;
+    sampler2D opacityTexture;
+    vec2 opacityTextureUVScale;
     float opacity;
-    bool gammaCorrected;
+    float alphaCutoff;
+    float gamma;
+    bool useGammaCorrection;
+    bool useLighting;
 } material;
 
 varying vec2 uv;
@@ -67,11 +77,15 @@ vec3 applyLight(Light inputLight, vec3 surfaceColor, vec3 surfaceNormal, vec3 su
     float specularity = 0.0;
     float specularPower = max(1.0,material.smoothnessFactor);
     float specularOpacity = clamp(material.smoothnessFactor,0.0,1.0);
+    vec3 specularMap = texture(material.specularTexture, (uv * material.specularTextureUVScale)).rgb;
+    if(!material.useSpecularTexture){
+        specularMap = vec3(1,1,1);
+    }
     if(diffusion > 0.0){
         vec3 reflectDir = reflect(-surfaceLightDir, surfaceNormal);
         specularity = pow(max(0.0, dot(surfaceViewDir, reflectDir)), specularPower);
     }
-    vec3 specular = specularity * specularOpacity * normalize(material.specularColor) * lightIntensities;
+    vec3 specular = specularMap * (specularity * specularOpacity * normalize(material.specularColor) * lightIntensities);
 
     //linear color (color before gamma correction)
     return max(inputLight.brightness,0.0) * (ambient + lightPercentage*(diffuse + specular));
@@ -82,24 +96,39 @@ void main() {
     vec3 surfaceNormal = normalize(transpose(inverse(mat3(model))) * normal);
     vec3 surfacePos = vec3(model * vec4(vertex, 1));
     vec4 materialColor = vec4(normalize(material.diffuseColor),1);
-    vec4 surfaceColor = texture(material.diffuseTexture, (uv * material.diffuseTextureUVScale)) * materialColor;
+    vec4 surfaceColor = texture(material.diffuseTexture, (uv * material.diffuseTextureUVScale));
+    if(!material.useDiffuseTexture){
+        surfaceColor = vec4(1,1,1,1);
+    }
+    surfaceColor *=  materialColor;
     vec3 surfaceViewDir = normalize(cameraPosition - surfacePos);
+
+    vec3 opacityColor = texture(material.opacityTexture, (uv * material.opacityTextureUVScale)).rgb;
+    float opacityMap = max(max(opacityColor.r, opacityColor.g),opacityColor.b);
+    if(!material.useOpacityTexture){
+        opacityMap = 1;
+    }
     float opacity = clamp(material.opacity,0.0,1.0);
-    float surfaceOpacity = min(surfaceColor.a , opacity);
+    float surfaceOpacity = min(opacityMap, opacity);
+    if(surfaceOpacity < material.alphaCutoff) discard;
 
     //combine color from all the lights
     vec3 linearColor = vec3(0);
-    for(int i = 0; i < lightCount; ++i){
-        if(lights[i].brightness > 0){
-            linearColor += applyLight(lights[i], surfaceColor.rgb, surfaceNormal, surfacePos, surfaceViewDir);
+    if(material.useLighting){
+        for(int i = 0; i < lightCount; ++i){
+            if(lights[i].brightness > 0){
+                linearColor += applyLight(lights[i], surfaceColor.rgb, surfaceNormal, surfacePos, surfaceViewDir);
+            }
         }
+    } else {
+        linearColor = surfaceColor.rgb;
     }
 
 	//final color (after gamma correction)
     vec3 finalColor = linearColor.rgb;
-    if(material.gammaCorrected){
-        vec3 gamma = vec3(1.0/2.2);
-        finalColor = pow(linearColor, gamma);
+    if(material.useGammaCorrection){
+        vec3 gammaCorrection = vec3(1.0/material.gamma);
+        finalColor = pow(linearColor, gammaCorrection);
     }
     
     gl_FragColor = vec4(finalColor, surfaceOpacity);

--- a/src/Core/Material/Material.cpp
+++ b/src/Core/Material/Material.cpp
@@ -15,11 +15,22 @@ namespace CGEngine {
 		setParameter("diffuseTexturePath", params.diffuseTexturePath, ParamType::String);
 		setParameter("diffuseTextureUVScale", params.diffuseTextureUVScale, ParamType::V2);
 		setParameter("diffuseTexture", textures->load(params.diffuseTexturePath), ParamType::Texture2D);
-		setParameter("smoothnessFactor", params.smoothnessFactor, ParamType::Float);
-		setParameter("opacity", params.opacity, ParamType::Float);
-		setParameter("specularColor", params.specularColor, ParamType::RGBA);
 		setParameter("diffuseColor", params.diffuseColor, ParamType::RGBA);
-		setParameter("gammaCorrected", params.gammaCorrected, ParamType::Bool);
+		setParameter("specularTexturePath", params.specularTexturePath, ParamType::String);
+		setParameter("specularTextureUVScale", params.specularTextureUVScale, ParamType::V2);
+		setParameter("specularTexture", textures->load(params.specularTexturePath), ParamType::Texture2D);
+		setParameter("specularColor", params.specularColor, ParamType::RGBA);
+		setParameter("smoothnessFactor", params.smoothnessFactor, ParamType::Float);
+		setParameter("opacityTextureUVScale", params.opacityTextureUVScale, ParamType::V2);
+		setParameter("opacityTexture", textures->load(params.opacityTexturePath), ParamType::Texture2D);
+		setParameter("opacity", params.opacity, ParamType::Float);
+		setParameter("alphaCutoff", params.alphaCutoff, ParamType::Float);
+		setParameter("gamma", params.gamma, ParamType::Float);
+		setParameter("useGammaCorrection", params.useGammaCorrection, ParamType::Bool);
+		setParameter("useDiffuseTexture", params.useDiffuseTexture, ParamType::Bool);
+		setParameter("useSpecularTexture", params.useSpecularTexture, ParamType::Bool);
+		setParameter("useOpacityTexture", params.useOpacityTexture, ParamType::Bool);
+		setParameter("useLighting", params.useLighting, ParamType::Bool);
 	};
 
 	Material::Material(map<string, ParamData> materialParameters, ShaderProgramPath shaderPath) : Material(shaderPath) {

--- a/src/Core/Material/Material.h
+++ b/src/Core/Material/Material.h
@@ -7,25 +7,59 @@ using namespace sf;
 using namespace std;
 
 namespace CGEngine {
+	struct SurfaceDomain {
+		SurfaceDomain(float domainIntensity = 1.0f, Color domainColor = Color::White, string texturePath = "", Vector2f textureScale = { 1,1 }) : texturePath(texturePath), textureScale(textureScale), domainColor(domainColor), domainIntensity(domainIntensity) {};
+		SurfaceDomain(string texturePath, float domainIntensity = 1.0f, Color domainColor = Color::White, Vector2f textureScale = {1,1}) : SurfaceDomain(domainIntensity, domainColor, texturePath, textureScale) {};
+		SurfaceDomain(string texturePath, Vector2f textureScale, Color domainColor = Color::White, float domainIntensity = 1.0f) : SurfaceDomain(domainIntensity, domainColor, texturePath, textureScale) {};
+		SurfaceDomain(string texturePath, Color domainColor, float domainIntensity = 1.0f, Vector2f textureScale = { 1,1 }) : SurfaceDomain(domainIntensity, domainColor, texturePath, textureScale) {};
+
+		string texturePath;
+		Vector2f textureScale;
+		Color domainColor;
+		float domainIntensity;
+	};
+
 	struct SurfaceParameters {
-		SurfaceParameters(string diffuseTexturePath = "", Vector2f diffuseTextureUVScale = {1,1}, Color diffuseColor = Color::White, float smoothnessFactor = 32.f, float opacity = 1.0f, Color specularColor = Color::White, bool gammaCorrected = false) : diffuseTexturePath(diffuseTexturePath), diffuseTextureUVScale(diffuseTextureUVScale), diffuseColor(diffuseColor), smoothnessFactor(smoothnessFactor), opacity(opacity), specularColor(specularColor), gammaCorrected(gammaCorrected) {
-			params["diffuseTexturePath"] = diffuseTexturePath;
-			params["diffuseTextureUVScale"] = diffuseTextureUVScale;
-			params["smoothnessFactor"] = smoothnessFactor;
-			params["opacity"] = opacity;
-			params["specularColor"] = specularColor;
-			params["diffuseColor"] = diffuseColor;
-			params["gammaCorrected"] = gammaCorrected;
-		};
+		SurfaceParameters(string diffuseTexturePath = "", Vector2f diffuseTextureUVScale = { 1,1 }, Color diffuseColor = Color::White, string specularTexturePath = "", Vector2f specularTextureUVScale = { 1,1 }, Color specularColor = Color::White, float smoothnessFactor = 32.f, string opacityTexturePath = "", Vector2f opacityTextureUVScale = { 1,1 }, float opacity = 1.0f, float alphaCutoff = 0.01f, bool useGammaCorrection = false, float gamma = 2.2f, bool useLighting = true) :
+			diffuseTexturePath(diffuseTexturePath),
+			diffuseTextureUVScale(diffuseTextureUVScale),
+			diffuseColor(diffuseColor),
+			specularTexturePath(specularTexturePath),
+			specularTextureUVScale(specularTextureUVScale),
+			smoothnessFactor(smoothnessFactor),
+			opacityTexturePath(opacityTexturePath),
+			opacityTextureUVScale(opacityTextureUVScale),
+			opacity(opacity),
+			specularColor(specularColor),
+			gamma(gamma),
+			useGammaCorrection(useGammaCorrection),
+			useDiffuseTexture(diffuseTexturePath != ""),
+			useSpecularTexture(specularTexturePath != ""),
+			useOpacityTexture(opacityTexturePath != ""),
+			alphaCutoff(alphaCutoff),
+			useLighting(useLighting)
+		{ };
+
+		SurfaceParameters(SurfaceDomain diffuseDomain = SurfaceDomain(), SurfaceDomain specularDomain = SurfaceDomain(32.0f), SurfaceDomain opacityDomain = SurfaceDomain(), float alphaCutoff = 0.01f, bool useGammaCorrection = false, float gamma = 2.2f, bool useLighting = true) :
+			SurfaceParameters(diffuseDomain.texturePath, diffuseDomain.textureScale, diffuseDomain.domainColor, specularDomain.texturePath, specularDomain.textureScale, specularDomain.domainColor, specularDomain.domainIntensity, opacityDomain.texturePath, opacityDomain.textureScale, opacityDomain.domainIntensity, alphaCutoff, useGammaCorrection, gamma, useLighting) {};
 		
-		string diffuseTexturePath;
+		string diffuseTexturePath = "";
 		Vector2f diffuseTextureUVScale = { 1,1 };
-		float smoothnessFactor = 1.0f;
-		float opacity = 0.0f;
-		Color specularColor = Color::White;
 		Color diffuseColor = Color::White;
-		bool gammaCorrected = false;
-		map<string, any> params;
+		float smoothnessFactor = 1.0f;
+		string specularTexturePath = "";
+		Vector2f specularTextureUVScale = { 1,1 };
+		Color specularColor = Color::White;
+		string opacityTexturePath = "";
+		Vector2f opacityTextureUVScale;
+		float opacity = 0.0f;
+		float alphaCutoff = 0.01f;
+		float gamma = 2.2f;
+		bool useGammaCorrection = false;
+		bool useDiffuseTexture = true;
+		bool useSpecularTexture = false;
+		bool useOpacityTexture = false;
+		bool useLighting = true;
 	};
 	class Material {
 	public:
@@ -41,6 +75,16 @@ namespace CGEngine {
 			}
 			cout << "Material parameter " << paramName << " not found";
 			return nullopt;
+		}
+
+		template<typename T>
+		T* getParameterPtr(string paramName) {
+			auto iterator = materialParameters.find(paramName);
+			if (iterator != materialParameters.end()) {
+				return any_cast<T*>((*iterator).second.data);
+			}
+			cout << "Material parameter " << paramName << " not found";
+			return nullptr;
 		}
 
 		optional<ParamData> getParameter(string paramName);

--- a/src/Core/Mesh/Mesh.cpp
+++ b/src/Core/Mesh/Mesh.cpp
@@ -19,7 +19,6 @@ namespace CGEngine {
 
 	void Mesh::render(Transform transform) {
 		renderer.pullGL();
-		bindTexture();
 
 		//Combine SFML entity transform components with 3D transformation components
 		Vector2f position2d = world->getGlobalPosition(transform);
@@ -36,18 +35,18 @@ namespace CGEngine {
 		renderer.commitGL();
 	}
 
-	void Mesh::bindTexture() {
+	void Mesh::bindTexture(Texture* texture) {
 		if (renderer.setGLWindowState(true)) {
 			//Generate texture mipmaps and bind or clear
-			if (meshTexture != nullptr) {
-				(void)meshTexture->generateMipmap();
-				Texture::bind(&(*meshTexture));
+			if (texture != nullptr) {
+				(void)texture->generateMipmap();
+				Texture::bind(&(*texture));
 			}
 			else {
 				Texture::bind(nullptr);
 			}
+			renderer.setGLWindowState(false);
 		}
-		renderer.setGLWindowState(false);
 	}
 
 	void Mesh::setPosition(Vector3f pos) {

--- a/src/Core/Mesh/Mesh.h
+++ b/src/Core/Mesh/Mesh.h
@@ -19,7 +19,7 @@ namespace CGEngine {
 		Mesh(VertexModel model, Transformation3D transformation = Transformation3D(), Material* material = new Material(), RenderParameters renderParams = RenderParameters());
 
 		void render(Transform parentTransform);
-		void bindTexture();
+		void bindTexture(Texture* texture);
 		void setPosition(Vector3f pos);
 		void move(Vector3f delta);
 		void setRotation(Vector3f rot);

--- a/src/Core/World/Renderer.cpp
+++ b/src/Core/World/Renderer.cpp
@@ -14,7 +14,6 @@ namespace CGEngine {
 
 		// Enable Z-buffer read and write
 		glEnable(GL_DEPTH_TEST);
-		glDepthFunc(GL_LESS);
 		glEnable(GL_BLEND);
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
@@ -132,7 +131,6 @@ namespace CGEngine {
 			for (size_t i = 0; i < lights.size(); ++i) {
 				setLightUniforms(lights.get(i), i, program);
 			}
-
 			// Draw the cube
 			glDrawArrays(GL_TRIANGLES, 0, model.vertices.size()/5);
 
@@ -153,6 +151,7 @@ namespace CGEngine {
 			Vector2f v2Data = { 0,0 };
 			Vector3f v3Data = { 0,0,0 };
 			Color colorData = { 0,0,0,0 };
+			Texture* textureData = nullptr;
 			if (paramData.has_value()) {
 				any paramVal = paramData.value().data;
 				ParamType paramType = paramData.value().type;
@@ -181,10 +180,17 @@ namespace CGEngine {
 					colorData = any_cast<Color>(paramVal);
 					program->setUniform(getUniformObjectPropertyName("material", paramName).c_str(), toGlm(colorData));
 					break;
-				//case MaterialParameterType::String:
-				//	break;
-				//case MaterialParameterType::Texture2D:
-				//	break;
+				case ParamType::Texture2D:
+					textureData = any_cast<Texture*>(paramVal);
+					if (textureData != nullptr) {
+						glActiveTexture(GL_TEXTURE0 + textureData->getNativeHandle());
+						glBindTexture(GL_TEXTURE_2D, textureData->getNativeHandle());
+						program->setUniform(getUniformObjectPropertyName("material", paramName).c_str(), (int)textureData->getNativeHandle());
+						glActiveTexture(GL_TEXTURE0);
+					}
+					break;
+				//case ParamType::String:
+					//	break;
 				default:
 					break;
 				}


### PR DESCRIPTION
- Allows for multiple textures per shader
- Introduces many new Material properties:
- Easier Material creation via SurfaceParameters and SurfaceDomain structs
- Diffuse, specular, and opacity scale-able, repeatable textures, with customizable intensity and color (where available)
- Optional textures
- Optional gamma correction
- Toggle lighting enabled per material