### PR TITLE
Fix OGL render calls on closed window in World

### DIFF
--- a/src/Core/World/Renderer.cpp
+++ b/src/Core/World/Renderer.cpp
@@ -72,7 +72,7 @@ namespace CGEngine {
 		// Make the window no longer the active window for OpenGL calls
 		bool success = window->setActive(state);
 		if (!success) {
-			std::cerr << "Failed to set window to " << ((state) ? "active" : "inactive") << std::endl;
+			cerr << "Failed to set window to " << ((state) ? "active" : "inactive") << endl;
 		}
 		return success;
 	}

--- a/src/Core/World/World.cpp
+++ b/src/Core/World/World.cpp
@@ -344,8 +344,10 @@ namespace CGEngine {
                 callScripts(onUpdateEvent);
                 input->gather();
                 
-                renderer.clearGL(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-                if (!renderer.processRender()) return;
+                if (window->isOpen()) {
+                    renderer.clearGL(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+                    if (!renderer.processRender()) return;
+                }
             }
         }
     }
@@ -420,16 +422,12 @@ namespace CGEngine {
     }
 
     id_t World::receiveBodyId(Body* body) {
-        //return ids.receive(&body->bodyId);
-
         id_t id = bodies.add(body);
         body->bodyId = id;
         return id;
     }
 
     void World::refundBodyId(Body* body) {
-        //ids.refund(&body->bodyId);
-
         optional<id_t> bodyId = body->getId();
         if (bodyId.has_value()) {
             bodies.remove(bodyId.value());
@@ -450,7 +448,7 @@ namespace CGEngine {
         }
     };
 
-    bool World::getBoundsRenderingEnabled() {
+    bool World:: getBoundsRenderingEnabled() const {
         return boundsRendering;
     };
 

--- a/src/Core/World/World.h
+++ b/src/Core/World/World.h
@@ -36,7 +36,7 @@ namespace CGEngine {
         //Bounds Renderings
         void setBoundsRenderingEnabled(bool enabled);
         void setBoundsRenderingEnabled(bool enabled, Body* body);
-        bool getBoundsRenderingEnabled();
+        bool getBoundsRenderingEnabled() const;
         void setBoundsColor(Color color);
         void setBoundsColor(Color color, Body* body);
         void setBoundsThickness(float thickness);


### PR DESCRIPTION
*Major*
- Adds window->isOpen() check before OGL renderer.clear() & renderer.processRender() functions, which attampt to set the window active/inactive, even if closed by input (like ESC)

*Minor*
- Removes unnecessary std namespace usages
- Removes unused calls to World.ids
- Sets World.getBoundsRenderingEnabled() const