### PR TITLE
Logging accepts numeric, string, char, char* args

### DIFF
--- a/src/Core/Logging/Logging.h
+++ b/src/Core/Logging/Logging.h
@@ -4,6 +4,7 @@
 #include <queue>
 #include <fstream>
 #include <filesystem>
+#include <cmath>
 using std::string;
 using std::cout;
 using std::queue;
@@ -25,21 +26,54 @@ namespace CGEngine {
 		Logging(LogLevel level = LogLevel::LogWarn);
 		~Logging();
 		string logFilename;
-		void operator()(LogLevel level, string caller, string msg, bool newLine = true, bool toFile = true);
-		void operator()(string msg, LogLevel level = LogLevel::LogInfo, string caller = "", bool newLine = true, bool toFile = true);
-		void operator()(string msg, string caller, LogLevel level, bool newLine = true, bool toFile = true);
+
+		//Numeric to string
+		template <typename T>
+		enable_if_t<is_arithmetic_v<T>, string> argToString(T value) {
+			stringstream sstream;
+			sstream << fixed << setprecision(precision) << value;
+			return sstream.str();
+		}
+		//String to string
+		template <typename T>
+		enable_if_t<is_same_v<T, string>, string> argToString(const T& value) {
+			return value;
+		}
+		//String literal to string
+		template <size_t N>
+		string argToString(const char(&value)[N]) {
+			return string(value);
+		}
+		//Char* to string
+		string argToString(const char* value) {
+			return string(value);
+		}
+		//Char to string
+		string argToString(const char value) {
+			return string(1,value);
+		}
+
+		template <typename... Args>
+		void operator()(LogLevel level, string caller, string msg, Args... args) {
+			log(level, caller, msg, { argToString(forward<Args>(args))... });
+		}
+
 		bool willLog(LogLevel level);
 		void setActive(bool enabled);
 		bool getActive();
 		queue<LogEvent> logQueue;
 		void queueMsg(LogEvent msgEvt);
 		void writeQueue();
+		void setPrecision(size_t precision);
 	protected:
 		static LogLevel logLevel;
 	private:
 		string filepath;
+		string logDirectory = "logs/";
 		bool active = true;
-		void log(LogLevel level, string caller, string msg, bool newLine = true, bool toFile = true);
+		size_t precision = 2;
+		void log(LogLevel level, string caller, string msg, vector<string> args, size_t precision = 2);
+		string format(string msg, vector<string> args);
 		void findUniqueFilepath();
 		string levelToString(LogLevel level);
 	};


### PR DESCRIPTION
- Implement logging that accepts numeric, string, char, and char* args and formatting values in log messages
- Logging has class-level numeric precision value for parsing float/double