### PR TITLE
Initial EngineSys for ScriptMap,ScriptDomain,TimerMap

### DIFF
--- a/src/Core/Behavior/Behavior.cpp
+++ b/src/Core/Behavior/Behavior.cpp
@@ -7,6 +7,7 @@ namespace CGEngine {
 		if (owner != nullptr) {
 			behaviorId = owner->addBehavior(this);
 		}
+		scripts.initialize();
 	};
 
 	id_t Behavior::addScript(string domain, Script* script) {

--- a/src/Core/Body/Body.cpp
+++ b/src/Core/Body/Body.cpp
@@ -75,6 +75,7 @@ namespace CGEngine {
 
     void Body::setName(string name) {
         bodyParams.name = name;
+        scripts.initialize();
     }
 
     Transformable* Body::get() const {

--- a/src/Core/Scripts/ScriptDomain.cpp
+++ b/src/Core/Scripts/ScriptDomain.cpp
@@ -5,6 +5,8 @@ namespace CGEngine {
     ScriptDomain::ScriptDomain(string name, string bodyName) {
         domainName = name;
         ownerName = bodyName;
+        init();
+        setSystemName(ownerName.append(ownerName==""?"":" ").append("Domain(").append(name).append(")"));
     }
 
     ScriptDomain::~ScriptDomain() {
@@ -22,7 +24,7 @@ namespace CGEngine {
     size_t ScriptDomain::addScript(Script* script) {
         size_t id = domainIds.receive(&script->id);
         scripts[id] = script;
-        logger("Added Script[" + to_string(id) + "]('" + domainName + "')");
+        log(this, LogInfo, "Added Script Id {}", id);
         return id;
     }
 
@@ -46,7 +48,7 @@ namespace CGEngine {
         if (script->id.has_value()) {
             size_t scriptId = script->id.value();
             if (shouldLog) {
-                logger("Removed Script[" + to_string(scriptId) + "]('" + domainName + "')");
+                log(this, LogInfo, "Removed Script Id {}", scriptId);
             }
             //Refund the script id and erase it from the scripts map
             domainIds.refund(&script->id);
@@ -168,26 +170,20 @@ namespace CGEngine {
             }
         }
         if (scripts.size() > 0) {
-            log(LogLevel::LogWarn, "ScriptDomainError", "Not all scripts of domain were deleted");
+            log(this, LogWarn, "Scripts remain after deletion");
             clear();
         }
-        logger("Deleted Domain('" + domainName + "')");
+        log(this, LogInfo, "Deleted Domain");
         delete this;
     }
 
     void ScriptDomain::deleteScript(Script* script, optional<id_t> scriptId) {
         if (script == nullptr) return;
         if (script->id.has_value()) {
-            logger("Deleted Script[" + to_string(script->id.value()) + "]('" + domainName + "')");
-        }
-        else if (scriptId.has_value()) {
-            logger("Deleted Script[" + to_string(scriptId.value()) + "]('" + domainName + "')");
+            log(this, LogInfo, "Deleted Script Id {}", script->id.value());
+        } else if (scriptId.has_value()) {
+            log(this, LogInfo, "Deleted Script Id {}", scriptId.value());
         }
         delete script;
-    }
-
-    void ScriptDomain::logger(string msg) {
-        if (!log.willLog(logLevel)) return;
-        log(LogLevel::LogWarn, ownerName, msg);
     }
 }

--- a/src/Core/Scripts/ScriptDomain.h
+++ b/src/Core/Scripts/ScriptDomain.h
@@ -8,7 +8,7 @@
 using namespace std;
 
 namespace CGEngine {
-    class ScriptDomain {
+    class ScriptDomain : public EngineSystem {
     public:
         ScriptDomain(string name, string bodyName = "");
         ~ScriptDomain();
@@ -67,14 +67,11 @@ namespace CGEngine {
         /// <param name="scriptId">The id of the Script to assign the data to</param>
         /// <param name="data">The DataStack to pass as input</param>
         void setScriptInput(size_t scriptId, DataMap data);
-        
-        LogLevel logLevel = LogLevel::LogInfo;
     private:
         string domainName;
         string ownerName = "";
         map<size_t, Script*> scripts;
         UniqueIntegerStack<size_t> domainIds = UniqueIntegerStack<size_t>(1000U);
         void deleteScript(Script* script, optional<id_t> scriptId = nullopt);
-        void logger(string msg);
     };
 }

--- a/src/Core/Scripts/ScriptMap.cpp
+++ b/src/Core/Scripts/ScriptMap.cpp
@@ -3,17 +3,19 @@
 
 namespace CGEngine {
 	ScriptMap::ScriptMap(Body* o) {
+		init();
 		owner = o;
 	}
 
 	void ScriptMap::initialize() {
 		if (owner == nullptr) {
-			ownerName = "Behavior"; 
 			return;
 		}
+		//Owner name == null on load for now
 		string namePrompt = (owner->getName() != "") ? "(" + owner->getName() + ")" : "";
 		string idPrompt = owner->getId().has_value() ? "[" + to_string(owner->getId().value()) + "]" : "";
-		ownerName = "Body" + idPrompt + namePrompt;
+		ownerName = idPrompt != "" || namePrompt != "" ? "Body" + idPrompt + namePrompt : "";
+		setSystemName(ownerName.append(ownerName!=""?" ":"").append("ScriptMap"));
 	}
 
 	size_t ScriptMap::addScript(string domainName, Script* script) {
@@ -64,7 +66,7 @@ namespace CGEngine {
 	}
 
 	void ScriptMap::clearDomain(string domainName) {
-		logger("Clearing Domain('" + domainName + "')");
+		log(this, LogInfo, "Clearing Domain '{}'", domainName);
 		if (ScriptDomain* domain = getDomain(domainName)) {
 			domain->clear();
 		}
@@ -79,7 +81,7 @@ namespace CGEngine {
 	void ScriptMap::callDomain(string domainName, Behavior* behavior, bool logUpdate) {
 		if (ScriptDomain* domain = getDomain(domainName)) {
 			if (domainName != onUpdateEvent || logUpdate) {
-				logger("Calling Domain('" + domain->getName() + "')");
+				log(this, LogInfo, "Calling Domain '{}'", domain->getName());
 			}
 			domain->callDomain(owner, behavior);
 		}
@@ -87,7 +89,7 @@ namespace CGEngine {
 
 	void ScriptMap::callScript(string domainName, size_t scriptId, Behavior* behavior) {
 		if (ScriptDomain* domain = getDomain(domainName)) {
-			logger("Calling Script[" + to_string(scriptId) + "]('" + domain->getName() + "')");
+			log(this, LogInfo, "Calling Script '{}'.'{}'", domain->getName(), to_string(scriptId));
 			domain->callScript(scriptId, owner, behavior);
 		}
 	}
@@ -95,7 +97,7 @@ namespace CGEngine {
 	void ScriptMap::callDomainWithData(string domainName, Behavior* behavior, DataMap input, bool logUpdate) {
 		if (ScriptDomain* domain = getDomain(domainName)) {
 			if (domainName != onUpdateEvent || logUpdate) {
-				logger("Calling Domain('" + domain->getName() + "')");
+				log(this, LogInfo, "Calling Domain '{}'", domain->getName());
 			}
 			domain->callDomain(owner, behavior, input);
 		}
@@ -103,7 +105,7 @@ namespace CGEngine {
 
 	void ScriptMap::callScriptWithData(string domainName, size_t scriptId, Behavior* behavior, DataMap input) {
 		if (ScriptDomain* domain = getDomain(domainName)) {
-			logger("Calling Script[" + to_string(scriptId) + "]('" + domain->getName() + "')");
+			log(this, LogInfo, "Calling Script '{}'.'{}'", domain->getName(), to_string(scriptId));
 			domain->callScript(scriptId, owner,  input, behavior);
 		}
 	}
@@ -116,7 +118,7 @@ namespace CGEngine {
 
 	ScriptDomain* ScriptMap::addDomain(string domainName) {
 		domains[domainName] = new ScriptDomain(domainName, ownerName);
-		logger("Added Domain('" + domainName + "')");
+		log(this, LogInfo, "Added Domain '{}'", domainName);
 		return domains[domainName];
 	}
 
@@ -143,10 +145,5 @@ namespace CGEngine {
 			//Refunds script ids, erase them from the domain's scripts map & delete them, then clear the map. Prints a warning if scripts remain
 			domain->deleteDomain();
 		}
-	}
-
-	void ScriptMap::logger(string msg) {
-		if (!log.willLog(logLevel)) return;
-		log(logLevel, ownerName, msg);
 	}
 }

--- a/src/Core/Scripts/ScriptMap.h
+++ b/src/Core/Scripts/ScriptMap.h
@@ -4,7 +4,7 @@
 #include "../Logging/Logging.h"
 
 namespace CGEngine {
-	class ScriptMap {
+	class ScriptMap : public EngineSystem{
 	public:
 		ScriptMap(Body* o);
 		size_t addScript(string domainName, Script* script);
@@ -19,9 +19,9 @@ namespace CGEngine {
 		void callDomainWithData(string domainName, Behavior* behavior = nullptr, DataMap input = DataMap(), bool logUpdate = false);
 		void callScriptWithData(string domainName, size_t scriptId, Behavior* behavior = nullptr, DataMap input = DataMap());
 		void deleteDomain(string domainName);
-		LogLevel logLevel = LogLevel::LogInfo;
 	private:
 		friend class Body;
+		friend class Behavior;
 		Body* owner = nullptr;
 		string ownerName = "";
 		map<string, ScriptDomain*> domains;
@@ -30,6 +30,5 @@ namespace CGEngine {
 		ScriptDomain* getDomain(string domainName);
 		void deleteDomains();
 		void deleteDomain(ScriptDomain* domain);
-		void logger(string msg);
 	};
 }

--- a/src/Core/Timers/TimerMap.cpp
+++ b/src/Core/Timers/TimerMap.cpp
@@ -2,14 +2,14 @@
 #include "../Engine/Engine.h"
 
 namespace CGEngine {
+    TimerMap::TimerMap() {
+        init();
+    }
+
     timerId_t TimerMap::setTimer(Body* body, sec_t duration, Script* onCompleteEvent, int loopCount, string timerDisplayName) {
         if (body == nullptr) return nullopt;
         if (duration <= 0) {
-            if (log.willLog(LogLevel::LogWarn)) {
-                string namePrompt = (body->getName() != "") ? "(" + body->getName() + ")" : "";
-                string idPrompt = body->getId().has_value() ? "[" + to_string(body->getId().value()) + "]" : "";
-                log(LogLevel::LogWarn, "Body" + idPrompt + namePrompt, "Timer not set. Duration must be > 0 but it was [" + to_string(duration) + "]");
-            }
+            log(this, LogLevel::LogWarn, "Timer not set. Duration must be > 0 but it was {}", duration);
             return nullopt;
         }
 
@@ -20,7 +20,7 @@ namespace CGEngine {
         //Take a unique id for the timer and assign it to the timer
         id_t id = timers.add(timer);
         timer->id = id;
-        logger(timer->name, id, "SET(" + to_string(duration) + " sec)");
+        log(this, LogInfo, "'{}'[{}] SET({} sec)", timer->name, id, duration);
         //Get the timer domain name by its timer id
         string timerDomain = "timer" + to_string(id);
         //Add the onComplete event to the body's timer domain by timer id
@@ -31,8 +31,7 @@ namespace CGEngine {
         timer->eventId = body->addUpdateScript(new Script([this, id, expiration, loopDuration, loopCount, onCompleteEvent](ScArgs args) {
             //OnUpdate: Check if the world time >= expiration time
             if (time.getElapsedSec() >= expiration) {
-                //LOGGING
-                logger(timers.get(id)->name, id, "DONE");
+                log(this, LogInfo, "'{}'[{}] DONE", timers.get(id)->name, id);
                 //Get the timer domain name by its timer id
                 string timerDomainById = "timer" + to_string(id);
                 string timerName = timers.get(id)->name;
@@ -62,15 +61,13 @@ namespace CGEngine {
                 }
             }
         }));
-        //LOGGING
-        logger(timer->name, id, "START(" + to_string(duration) + " sec)");
+        log(this, LogInfo, "'{}'[{}] START({} sec)", timer->name, id, duration);
         return id;
     }
 
     void TimerMap::cancelTimer(Body* body, size_t timerId) {
         Timer* timer = timers.get(timerId);
-        //LOGGING
-        logger(timer->name, timerId, "STOP");
+        log(this, LogInfo, "'{}'[{}] STOP", timer->name, timerId);
         //Delete the domain for the timer id
         body->deleteDomain("timer" + to_string(timerId));
         //Remove this timer's update script
@@ -84,8 +81,7 @@ namespace CGEngine {
         if (timerId->has_value()) {
             id_t id = timerId->value();
             Timer* timer = timers.get(id);
-            //LOGGING
-            logger(timer->name, id, "STOP");
+            log(this, LogInfo, "'{}'[{}] STOP", timer->name, id);
             //Delete the domain for the timer id
             body->deleteDomain("timer" + to_string(id));
             //Remove this timer's update script
@@ -99,11 +95,6 @@ namespace CGEngine {
 
     void TimerMap::deleteTimers(Body* body) {
         timers.forEach([this, &body](Timer* timer) {
-            if (log.willLog(logLevel)) {
-                string namePrompt = (body->getName() != "") ? "(" + body->getName() + ")" : "";
-                string idPrompt = body->getId().has_value() ? "[" + to_string(body->getId().value()) + "]" : "";
-                log(logLevel, "Body" + idPrompt + namePrompt, "Deleting Timer(" + timer->name + ")");
-            }
             delete timer;
         });
     }
@@ -112,14 +103,6 @@ namespace CGEngine {
         Timer* timer = timers.get(timerId);
         timers.remove(timerId);
         delete timer;
-    }
-
-    void TimerMap::logger(string timerName, size_t timerId, string msg) {
-        if (!log.willLog(logLevel)) return;
-
-        string name = (timerName != "") ? "(" + timerName + ")" : "";
-        string caller = "Timer[" + to_string(timerId) + "]" + name;
-        log(logLevel, caller, msg);
     }
 
     void TimerMap::clear() {

--- a/src/Core/Timers/TimerMap.h
+++ b/src/Core/Timers/TimerMap.h
@@ -5,6 +5,7 @@
 #include "../Types/Types.h"
 #include "../Logging/Logging.h"
 #include "../Types/UniqueDomain.h"
+#include "../Engine/EngineSystem.h"
 using namespace std;
 
 namespace CGEngine {
@@ -13,8 +14,9 @@ namespace CGEngine {
 	class Body;
 	class Script;
 
-	class TimerMap {
+	class TimerMap : public EngineSystem {
 	public:
+		TimerMap();
 		/// <summary>
 		/// Set a timer on the indicated body for the duration, calling the onCompleteEvent when the duration expires and resetting
 		/// the timer up to loopCount timers when it is completed
@@ -47,23 +49,12 @@ namespace CGEngine {
 		/// Clear all timer entries (but doesn't delete them)
 		/// </summary>
 		void clear();
-		/// <summary>
-		/// The LogLevel of logs from this class
-		/// </summary>
-		LogLevel logLevel = LogLevel::LogInfo;
 	private:
 		/// <summary>
 		/// Delete the timer with the indicated id and erase it from the TimerMap
 		/// </summary>
 		/// <param name="timerId">The id of the timer to delete</param>
 		void deleteTimer(size_t timerId);
-		/// <summary>
-		/// Log the message with the Timer name and Id
-		/// </summary>
-		/// <param name="timerName">The timer display name</param>
-		/// <param name="timerId">The timer id</param>
-		/// <param name="msg">The log message</param>
-		void logger(string timerName, size_t timerId, string msg);
 		/// <summary>
 		/// A unique id list of timers
 		/// </summary>

--- a/src/Core/World/World.cpp
+++ b/src/Core/World/World.cpp
@@ -5,7 +5,6 @@
 namespace CGEngine {
     World::World() : root(bodies.get(create())) {
         init();
-        log(this, LogLevel::LogWarn, "Warning! Warning! {} Things are wrong!", 3);
     }
 
     void World::initializeConsole() {


### PR DESCRIPTION
- Update ScriptMap, ScriptDomain, and TimerMap to inherit from EngineSystem, calling init() on constructor to generate a system name
- Replaces per-system logger methods with calls to Engine.h's log object, providing the EngineSystem instance to determine per-system log level applicability
- Fixes Behavior to properly initialize its ScriptMap