### PR TITLE
Implement initial AssetLoaders for AssetManager.load

### DIFF
--- a/src/Core/AssetManager/AssetLoader.h
+++ b/src/Core/AssetManager/AssetLoader.h
@@ -1,0 +1,94 @@
+#pragma once
+#include <string>
+#include "../Types/Types.h"
+using std::string;
+
+namespace CGEngine {
+	class AssetLoader {
+	public:
+		virtual IResource* load(const filesystem::path& resourcePath) = 0;
+	protected:
+		LogLevel logLevel = LogLevel::LogInfo;
+		void logMessage(LogLevel level, const string& msg) {
+			if (level <= logLevel) {
+				cout << "[" << logLevels[(int)level] << "] AssetManager: " << msg << "\n";
+			}
+		}
+	};
+
+	class TextureLoader : public AssetLoader{
+	public:
+		TextureResource* load(const filesystem::path& resourcePath) override {
+			TextureResource* resource = nullptr;
+			//Ensure the resource loading path exists
+			if (filesystem::exists(resourcePath)) {
+				resource = new TextureResource();
+				Texture* texture = new Texture();
+				if (texture->loadFromFile(resourcePath.string())) {
+					resource->setTexture(texture);
+				}
+				else {
+					string logMsg = string("Failed to load texture: ").append(resourcePath.string());
+					logMessage(LogError, logMsg);
+					delete resource;
+					delete texture;
+					return nullptr;
+				}
+			}
+			else {
+				string logMsg = string("Texture file not found: ").append(resourcePath.string());
+				logMessage(LogError, logMsg);
+				return nullptr;
+			}
+			return resource;
+		}
+	};
+
+	class FontLoader : public AssetLoader {
+	public:
+		FontResource* load(const filesystem::path& resourcePath) override {
+			FontResource* resource = new FontResource();
+			//Ensure the resource loading path exists
+			if (filesystem::exists(resourcePath)) {
+				try {
+					Font* font = new Font(resourcePath);
+					resource->setFont(font);
+				}
+				catch (sf::Exception ex) {
+					string logMsg = string("Font failed to load: ").append(ex.what());
+					logMessage(LogInfo, logMsg);
+					delete resource;
+					return nullptr;
+				}
+			}
+			else {
+				delete resource;
+				return nullptr;
+			}
+		}
+	};
+
+	class VertexShaderLoader : public AssetLoader {
+	public:
+		Shader* load(const filesystem::path& resourcePath) override {
+			Shader shader = Shader::readFile(resourcePath.string(), GL_VERTEX_SHADER);
+			if (!shader.isValid()) {
+				logMessage(LogWarn, string("Vertex Shader loaded from '").append(resourcePath.filename().string()).append("' is invalid!"));
+				return nullptr;
+			}
+			return &shader;
+		}
+	};
+
+	class FragmentShaderLoader : public AssetLoader{
+	public:
+		Shader* load(const filesystem::path& resourcePath) {
+			Shader shader = Shader::readFile(resourcePath.string(), GL_FRAGMENT_SHADER);
+			if (!shader.isValid()) {
+				logMessage(LogWarn, string("Fragment Shader loaded from '").append(resourcePath.filename().string()).append("' is invalid!"));
+				return nullptr;
+			}
+			return &shader;
+		}
+	};
+}

--- a/src/Core/Body/Body.cpp
+++ b/src/Core/Body/Body.cpp
@@ -60,7 +60,7 @@ namespace CGEngine {
             boundsRect = nullptr;
         }
         //Detach any children, then clear the children
-        detachChildren();
+        detachChildren(false);
         children.clear();
         //Remove reference to this Body in its parent, then clear parent
         drop();
@@ -405,16 +405,16 @@ namespace CGEngine {
                 child->rotate(getRotation());
                 child->scale(getScale());
             }
+            // Check if world and world's root are still valid before attaching
+            //if (world && world->getRoot() && world->getRoot()->isValid()) {
+            //    world->getRoot()->attachBody(child);
+            //} else {
+            //    // If world root is not available, just set parent to nullptr
+            //    // This prevents trying to attach to an invalid body
+            //    child->parent = nullptr;
+            //}
             //Remove child from children
             children.erase(children.begin() + i);
-            // Check if world and world's root are still valid before attaching
-            if (world && world->getRoot() && world->getRoot()->isValid()) {
-                world->getRoot()->attachBody(child);
-            } else {
-                // If world root is not available, just set parent to nullptr
-                // This prevents trying to attach to an invalid body
-                child->parent = nullptr;
-            }
         }
     }
 


### PR DESCRIPTION
- Implements initial Texture, Font, Vertex and Fragment Shader AssetLoaders to replace hard-coded loading in AssetManager
- Disables Body child detachment as it is broken