### PR TITLE
Update Animator, Model and Importer to use AssetManager ids

### DIFF
--- a/src/Core/Animation/Animator.cpp
+++ b/src/Core/Animation/Animator.cpp
@@ -2,7 +2,7 @@
 #include "../Engine/Engine.h"
 
 namespace CGEngine {
-	Animator::Animator(const string& animationName) {
+	Animator::Animator(const string& animationName):currentAnimation(nullptr) {
 		init();
 		boneMatrices.reserve(100);
 		for (int i = 0; i < 100; i++) {

--- a/src/Core/Importer/MeshImporter.cpp
+++ b/src/Core/Importer/MeshImporter.cpp
@@ -31,7 +31,7 @@ namespace CGEngine {
         return ImportResult();
     }
 
-	void MeshImporter::importAnimations(const aiScene* scene, map<string,BoneData> modelBones, map<string, Animation*>& modelAnimations) {
+	void MeshImporter::importAnimations(const aiScene* scene, map<string,BoneData> modelBones, vector<string>& modelAnimations) {
 		if (scene->HasAnimations()){
 			log(this, LogInfo, "- Importing {} Animations", scene->mNumAnimations);
 
@@ -50,7 +50,7 @@ namespace CGEngine {
 				// Cache the animation using AssetManager
 				optional<id_t> animationId = assets.add<Animation>(animName, animation);
 				if (animationId.has_value()) {
-					modelAnimations[animName] = assets.get<Animation>(animationId.value());
+					modelAnimations.push_back(animName);
 					log(this, LogInfo, "  - Successfully Imported Animation '{}' with {} Channels and {} Bones", animation->getName(), anim->mNumChannels, animation->bones.size());
 				}
 				else {
@@ -242,7 +242,7 @@ namespace CGEngine {
 		// Import animations if path available
 		if (!meshData->sourcePath.empty()) {
 			const aiScene* scene = modelImporter.ReadFile(meshData->sourcePath,0U);
-			map<string, Animation*> modelAnimations;
+			vector<string> modelAnimations;
 			importAnimations(scene, meshData->bones, modelAnimations);
 		}
 

--- a/src/Core/Importer/MeshImporter.h
+++ b/src/Core/Importer/MeshImporter.h
@@ -28,7 +28,7 @@ namespace CGEngine {
 		ImportResult(MeshNodeData* rootNode) : rootNode(rootNode) {};
 		MeshNodeData* rootNode = nullptr;
 		vector<id_t> materials;
-		map<string, Animation*> animations;
+		vector<string> animations;
 	};
 
 	// Add new helper struct to track skeletal data during import
@@ -78,7 +78,7 @@ namespace CGEngine {
         vector<string> loadMaterialTextures(aiMaterial* mat, aiTextureType type);
 		unsigned int getFormatOptions(string format);
 		string getFormat(string path);
-		void importAnimations(const aiScene* scene, map<string, BoneData> modelBones, map<string, Animation*>& modelAnimations);
+		void importAnimations(const aiScene* scene, map<string, BoneData> modelBones, vector<string>& modelAnimations);
         Assimp::Importer modelImporter;
 		const aiScene* currentScene = nullptr;
     };

--- a/src/Core/Mesh/Model.cpp
+++ b/src/Core/Mesh/Model.cpp
@@ -134,7 +134,7 @@ namespace CGEngine {
 
 		// Create animator with first available animation
 		if (!modelAnimations.empty()) {
-			string firstAnimationName = modelAnimations.begin()->first;
+			string firstAnimationName = *modelAnimations.begin();
 			return new Animator(firstAnimationName);
 		}
 		return nullptr;

--- a/src/Core/Mesh/Model.h
+++ b/src/Core/Mesh/Model.h
@@ -66,7 +66,7 @@ namespace CGEngine {
 		ModelNode* rootNode = nullptr;
 		map<string, BoneData> modelBones;
 		vector<id_t> modelMaterials;
-		map<string, Animation*> modelAnimations;
+		vector<string> modelAnimations;
 		map<string, AnimationNodeMapping> animationNodeMap;
 		Animator* modelAnimator = nullptr;
 		size_t bodyCount = 0;


### PR DESCRIPTION
- Updates the Animator, Model, and MeshImporter to use the Animation name via AssetManager ids when importing and storing Animations on the Model instead of raw pointers