### PR TITLE
Mesh Body reference to an id, override setId on Body

### DIFF
--- a/src/Core/Body/Body.cpp
+++ b/src/Core/Body/Body.cpp
@@ -13,10 +13,6 @@ namespace CGEngine {
     }
 
     Body::Body(Transformable* d, Transformation handle, Body* p, Vector2f uv) : Body() {
-        Mesh* meshEntity = dynamic_cast<Mesh*>(d);
-        if (meshEntity) {
-            meshEntity->setBody(this);
-        }
         //Cache the base transformable and cast it to a shape
         entity = d;
         //Create the bounds rect and set draw bounds to world's value
@@ -65,6 +61,13 @@ namespace CGEngine {
         //Remove reference to this Body in its parent, then clear parent
         drop();
         parent = nullptr;
+    }
+
+    void Body::setId(optional<id_t> id) {
+		IResource::setId(id);
+
+        Mesh* meshEntity = dynamic_cast<Mesh*>(entity);
+        if (meshEntity) meshEntity->setBodyId(getId());
     }
 
     //TODO: Properly implement isValid for this and other iResource classes

--- a/src/Core/Body/Body.h
+++ b/src/Core/Body/Body.h
@@ -595,6 +595,11 @@ namespace CGEngine {
         /// </summary>
         /// <param name="isWorldRoot">If true, the Body (the world root) will have a nullopt id</param>
         Body(bool isWorldRoot);
+        /// <summary>
+		/// Override IResource setId to set the Body's Mesh entity's bodyId to the provided id
+        /// </summary>
+        /// <param name="id"></param>
+        void setId(optional<id_t> id) override;
     private:
         friend class World;
         friend class Renderer;

--- a/src/Core/Mesh/Mesh.h
+++ b/src/Core/Mesh/Mesh.h
@@ -35,10 +35,10 @@ namespace CGEngine {
 		void clearMaterials();
 		string getMeshName() const;
 		string getSourcePath() const;
-		optional<id_t> getModel() const { return modelId; }
-		void setModel(optional<id_t> modelId) { this->modelId = modelId; }
-		Body* getBody() const { return body; }
-		void setBody(Body* body) { this->body = body; }
+		optional<id_t> getModelId() const { return modelId; }
+		void setModelId(optional<id_t> modelId) { this->modelId = modelId; }
+		optional<id_t> getBodyId() const { return bodyId; }
+		void setBodyId(optional<id_t> body) { this->bodyId = body; }
 		// Add new method to get combined transform
 		glm::mat4 getModelMatrix() const {
 			glm::mat4 modelPos = glm::translate(glm::vec3(transformation.position.x, transformation.position.y, transformation.position.z));
@@ -55,7 +55,7 @@ namespace CGEngine {
 	private:
 		string importPath;
 		optional<id_t> modelId;
-		Body* body = nullptr;
+		optional<id_t> bodyId;
 		MeshData* meshData;
 		Transformation3D transformation;
 		RenderParameters renderParameters;

--- a/src/Core/Mesh/Model.cpp
+++ b/src/Core/Mesh/Model.cpp
@@ -198,7 +198,7 @@ namespace CGEngine {
 
 		// Create a mesh for this node (even if empty)
 		Mesh* mesh = new Mesh(node->meshData, nodeTransform, nodeMaterials);
-		mesh->setModel(getId());
+		mesh->setModelId(getId());
 
 		// Create and attach child body
 		optional<id_t> bodyId = assets.create<Body>(sourcePath.append(node->nodeName), mesh);

--- a/src/Core/Types/Types.h
+++ b/src/Core/Types/Types.h
@@ -153,7 +153,7 @@ namespace CGEngine {
         virtual ~IResource() = default;
         virtual bool isValid() const = 0;
 		optional<id_t> getId() const { return id; }
-		void setId(optional<id_t> id) { this->id = id; }
+		virtual void setId(optional<id_t> id) { this->id = id; }
     private:
 		optional<id_t> id = nullopt;
     };

--- a/src/Core/World/Renderer.h
+++ b/src/Core/World/Renderer.h
@@ -224,6 +224,6 @@ namespace CGEngine {
 		GLenum checkGLError(const char* operation, const char* file, int line);
 		bool validateShader(Shader* shader);
 		bool validateProgram(Program* program);
-
+		glm::mat4 getBodyGlobalTransform(optional<id_t> bodyId);
 	};
 }


### PR DESCRIPTION
- Update Mesh's reference to its Body to the Body's id in the AssetManager
- Override setId in Body to set the Mesh entity bodyId reference to the same id (if the entity is a Mesh)