### PR TITLE
Behavior.GetId returns optional and lots of comments

### DIFF
--- a/src/Core/Behavior/Behavior.cpp
+++ b/src/Core/Behavior/Behavior.cpp
@@ -1,9 +1,7 @@
 #include "Behavior.h"
 
 namespace CGEngine {
-	Behavior::Behavior(Body* owning, string name) : scripts(owning) {
-		displayName = name;
-		owner = owning;
+	Behavior::Behavior(Body* owning, string displayName) : scripts(owning), displayName(displayName), owner(owning) {
 		if (owner != nullptr) {
 			behaviorId = owner->addBehavior(this);
 		}
@@ -18,8 +16,8 @@ namespace CGEngine {
 		scripts.removeScript(domain, scriptId, shouldDelete);
 	}
 
-	void Behavior::addScriptEventsByDomain(map<string, ScriptEvent> sc) {
-		for (auto iterator = sc.begin(); iterator != sc.end(); ++iterator) {
+	void Behavior::addScriptEventsByDomain(map<string, ScriptEvent> scripts) {
+		for (auto iterator = scripts.begin(); iterator != scripts.end(); ++iterator) {
 			string domain = (*iterator).first;
 			addScript((*iterator).first, new Script((*iterator).second));
 		}
@@ -34,8 +32,8 @@ namespace CGEngine {
 	}
 
 	
-	id_t Behavior::getId() {
-		return behaviorId.value_or(0U);
+	optional<id_t> Behavior::getId() {
+		return behaviorId.value();
 	}
 
 	Body* Behavior::getOwner() {

--- a/src/Core/Behavior/Behavior.h
+++ b/src/Core/Behavior/Behavior.h
@@ -12,18 +12,70 @@
 using namespace std;
 
 namespace CGEngine {
+	/// <summary>
+	/// Behavior contains a ScriptMap, like a Body, but does not hold a reference to a Drawable entity and
+	/// has not transform properties, like a Body. A Behavior is stateless or stateful, like a Script, via
+	/// its Input/Output/ProcessDataController. A Behavior's ScriptMap behaves in the same way as a Body and 
+	/// its "start", "update", and "delete" domains are called whenever the Body's are called during World Execution.
+	/// Behaviors are typically owned by a Body and used to handle data and events for that Body.
+	/// </summary>
 	class Behavior : public InputDataController, public OutputDataController, public ProcessDataController {
 	public:
-		Behavior(Body* owning, string name = "");
+		/// <summary>
+		/// Construct a Behavior with the display name, assigning the owning Body (if present) to the ScriptMap's owner pointer and to
+		/// the Behavior's owner pointer. The Behavior is assigned a unique id, if an owner is present, then the ScriptMap is initialized.
+		/// </summary>
+		/// <param name="owning">The Behavior's owning Body</param>
+		/// <param name="displayName">The display name of the Behavior</param>
+		Behavior(Body* owning, string displayName = "");
 
+		/// <summary>
+		/// Add a Script to the Behavior's ScriptMap at the given domain.
+		/// </summary>
+		/// <param name="domain">The string key of the ScriptDomain to add the Script to</param>
+		/// <param name="script">The Script to add to the domain</param>
+		/// <returns>The id of the Script within the ScriptDomain</returns>
 		id_t addScript(string domain, Script* script);
+		/// <summary>
+		/// Remove a Script with scriptId from the Behavior's ScriptMap at the given domain. If shouldDelete is true, delete the ScriptDomain
+		/// if it is empty after removing the Script.
+		/// </summary>
+		/// <param name="domain">The string key of the ScriptDomain to remove the Script from</param>
+		/// <param name="scriptId">The id of the Script to remove within the ScriptDomain</param>
+		/// <param name="shouldDelete">Whether or not the ScriptDomain should be deleted if empty after removal</param>
 		void removeScript(string domain, id_t scriptId, bool shouldDelete = false);
-		void addScriptEventsByDomain(map<string, ScriptEvent> sc);
+		/// <summary>
+		/// For each string key and ScriptEvent in the provided map, create a Script and assign the ScriptEvent to it, then add the Script to the ScriptDomain
+		/// at the string key.
+		/// </summary>
+		/// <param name="scripts">The map of string domain key to ScriptEvents to add (as Scripts)</param>
+		void addScriptEventsByDomain(map<string, ScriptEvent> scripts);
+		/// <summary>
+		/// Call each Script in the ScriptDomain with the indicated string key
+		/// </summary>
+		/// <param name="domain">The string key of the ScriptDomain to call</param>
 		void callDomain(string domain);
+		/// <summary>
+		/// Call each Script iin the ScriptDomain with the indicated string key, passing the DataMap as input to each Script
+		/// </summary>
+		/// <param name="domain">The string key of the ScriptDomain to call</param>
+		/// <param name="data">The input DataMap to pass to each Script called</param>
 		void callDomainWithData(string domain, DataMap data);
 
-		id_t getId();
+		/// <summary>
+		/// Get the id of the Behavior within the Body's Behavior list, if added to a Body.
+		/// </summary>
+		/// <returns>The id of the Behavior or nullopt, if not set</returns>
+		optional<id_t> getId();
+		/// <summary>
+		/// Return the Behavior's owning Body or nullptr, if not set
+		/// </summary>
+		/// <returns>The owning Body or nullptr</returns>
 		Body* getOwner();
+		/// <summary>
+		/// Return the Behavior's display name
+		/// </summary>
+		/// <returns>The Behavior's display name</returns>
 		string getName();
 	private:
 		string displayName = "";

--- a/src/Core/Input/InputMap.cpp
+++ b/src/Core/Input/InputMap.cpp
@@ -2,7 +2,7 @@
 #include "../Engine/Engine.h"
 
 namespace CGEngine {
-    InputMap::InputMap() { }
+    InputMap::InputMap() : window(nullptr) { }
 
     void InputMap::clear() {
         domains.clear();

--- a/src/Core/Input/InputMap.h
+++ b/src/Core/Input/InputMap.h
@@ -7,6 +7,11 @@ using namespace sf;
 using namespace std;
 
 namespace CGEngine {
+    /// <summary>
+	/// InputCondition describes an input condition for an input ScriptDomain. It contains the input id, type (button,key,char,cursor), 
+	/// and state (pressed, released, held, atomic). When input events are gathered in InputMap.gather(), the the domain with InputCondition
+	/// key matching the input event is called. The input id is the id of the input event (e.g. Mouse::Button::Left, Keyboard::Scan::A, etc.)
+    /// </summary>
     struct InputCondition {
         InputCondition(int i, InputType t, InputState s) :input(i), type(t), state(s) {};
         int input = -1;
@@ -22,29 +27,106 @@ namespace CGEngine {
         }
     };
 
+    /// <summary>
+	/// A variant of ScriptMap that keys Scripts by InputCondition, which is queryable by input event via input id, 
+    /// type (button,key,char,cursor), and state (pressed, released, held, atomic). The InputMap gathers input events 
+    /// in the gather() method and calls the domains with matching InputConditions. The InputMap primarily uses Actuators 
+    /// within its ScriptDomains because, unlike the ScriptMap, the Scripts in InputMap are not called from a Body, so the 
+    /// ScriptEvent cannot be passed a Body or Behavior. Instead, the Actuator passes the ScriptEvent the Body and/or 
+    /// Behavior assigned when the Actuator was created.
+    /// </summary>
     class InputMap {
     public:
         InputMap();
         void setWindow(RenderWindow* w);
         optional<Vector2i> getCursorPosition();
-
+        /// <summary>
+        /// Clear the the domains map.
+        /// </summary>
         void clear();
+        /// <summary>
+		/// Add an Actuator to the ScriptDomain at the given InputCondition, if it exists. If not, create a new ScriptDomain 
+        /// with the given InputCondition and add the Actuator to it.
+        /// </summary>
+        /// <param name="domainCondition">The InputCondition of the ScriptDomain to add the Actuator to, if it exists, or to create, if not</param>
+        /// <param name="script">The Actuator to add to the ScriptDomain at InputCondition</param>
+        /// <returns>The id of the Actuator in the ScriptDomain or nullopt, if not added</returns>
         optional<id_t> addActuator(InputCondition domainCondition, Actuator* script);
+        /// <summary>
+		/// Finds the ScriptDomain at the given InputCondition and removes the Actuator with the indicated id from it without deleting it.
+        /// </summary>
+        /// <param name="domainCondition">The InputCondition of the ScriptDomain to remove the Actuator from</param>
+        /// <param name="scriptId">The id of the Actuator to remove within the ScriptDomain</param>
         void removeActuator(InputCondition domainCondition, id_t scriptId);
+        /// <summary>
+        /// Finds the ScriptDomain at the given InputCondition and removes the indicated Actuator from it without deleting it.
+        /// </summary>
+        /// <param name="domainCondition">The InputCondition of the ScriptDomain to erase the Actuator from</param>
+        /// <param name="script">The Actuator to remove</param>
         void removeActuator(InputCondition domainCondition, Script* script);
+        /// <summary>
+        /// Finds the ScriptDomain at the given InputCondition and erases the Actuator with the indicated id from it, including deleting it.
+        /// </summary>
+        /// <param name="domainCondition">The InputCondition of the ScriptDomain to remove the Actuator from</param>
+        /// <param name="scriptId">The id of the Actuator to remove within the ScriptDomain</param>
         void eraseActuator(InputCondition domainCondition, id_t scriptId);
+        /// <summary>
+        /// Finds the ScriptDomain at the given InputCondition and erases the indicated Actuator from it, including deleting it.
+        /// </summary>
+        /// <param name="domainCondition">The InputCondition of the ScriptDomain to erase the Actuator from</param>
+        /// <param name="script">The Actuator to remove</param>
         void eraseActuator(InputCondition domainCondition, Script* script);
+        /// <summary>
+        /// Finds the ScriptDomain at the given InputCondition and erases the Actuators with the indicated ids from it, including deleting them.
+        /// </summary>
+        /// <param name="domainCondition">The InputCondition of the ScriptDomain to remove the Actuator from</param>
+        /// <param name="scriptIds">The ids of the Actuators to remove within the ScriptDomain</param>
         void eraseActuatorIds(map<InputCondition, vector<id_t>> scriptIds);
+        /// <summary>
+		/// Find the ScriptDomain by InputCondition. If not found, return nullptr.
+        /// </summary>
+        /// <param name="domainCondition">The InputCondition of the ScriptDomain</param>
+        /// <returns>The ScriptDomain at that InputCondition or nullptr if not found </returns>
         ScriptDomain* getDomain(InputCondition domainCondition);
+        /// <summary>
+        /// Find the ScriptDomain by Key input id. If not found, return nullptr.
+        /// </summary>
+        /// <param name="domainCondition">The InputCondition of the ScriptDomain</param>
+        /// <returns>The ScriptDomain at that Key id or nullptr if not found </returns>
         ScriptDomain* getKeyDomain(int input, InputState state);
+        /// <summary>
+        /// Find the ScriptDomain by Button input id. If not found, return nullptr.
+        /// </summary>
+        /// <param name="domainCondition">The InputCondition of the ScriptDomain</param>
+        /// <returns>The ScriptDomain at that Button id or nullptr if not found </returns>
         ScriptDomain* getButtonDomain(int input, InputState state);
+        /// <summary>
+		/// Find the Character ScriptDomain. If not found, return nullptr. The Character ScriptDomain has state
+		/// Atomic, which means it is called once per character input event, regardless of the input id.
+        /// </summary>
+        /// <param name="domainCondition">The InputCondition of the ScriptDomain</param>
+        /// <returns>The Character ScriptDomain or nullptr if not found </returns>
         ScriptDomain* getCharacterDomain();
+        /// <summary>
+		/// Find the Cursor ScriptDomain. If not found, return nullptr. The Cursor ScriptDomain has state
+		/// Atomic, which means it is called once per cursor input event, without the input id.
+        /// </summary>
+        /// <param name="domainCondition">The InputCondition of the ScriptDomain</param>
+        /// <returns>The Cursor ScriptDomain or nullptr if not found </returns>
         ScriptDomain* getCursorDomain();
+		//Find and, if found, call the domain with the input condition, passing the input data to the domain scripts
         void callDomain(InputCondition domainCondition, optional<map<string, any>> input = nullopt);
     protected:
         friend class World;
-        RenderWindow* window;
+        RenderWindow* window = nullptr;
+        /// <summary>
+		/// The ScriptDomains are stored in a map by their InputCondition. The InputCondition is a combination of the input id, type (button,key,char,cursor), and state (pressed, released, held, atomic).
+        /// InputMap ScriptDomains are called by their InputConditions when the InputMap gathers input events in the gather() method.
+        /// </summary>
         map<InputCondition, ScriptDomain*> domains;
+        /// <summary>
+		/// Called by the World to gather input events from the window and call the ScriptDomains with matching InputConditions.
+        /// </summary>
         void gather();
         optional<Vector2i> cursorPosition = nullopt;
     };

--- a/src/Core/Scripts/Actuator.h
+++ b/src/Core/Scripts/Actuator.h
@@ -3,10 +3,32 @@
 #include "Script.h"
 
 namespace CGEngine {
+	/// <summary>
+	/// An Actuator is a Script which is constructed with a Body and/or Behavior. When an Actuator is called, its ScriptEvent is called with the
+	/// Actuator's stored Body and/or Behavior instead of any Body or Behavior passed to it. This allows for the Actuator to pass its cached Body and/or
+	/// Behavior to the ScriptEvent, regardless of where the Actuator was called from.
+	/// 
+	/// In the engine, when a user adds an input script to a Body or Behavior, an Actuator is created in the InputMap and assigned that Body or Behavior, then 
+	/// when the input condition is met, the Actuator calls its ScriptEvent and passes the Body or Behavior to it. Without Actuators, Scipts expect to be called
+	/// from a ScriptMap and passed the ScriptMap's owning Body or Behavior, which would not be functional in the InputMap (which has no owning Body or Behavior).
+	/// </summary>
 	class Actuator : public Script {
 	public:
-		Actuator(ScriptEvent s, Body* calling = nullptr, Behavior* behavior = nullptr) : caller(calling), behavior(behavior), Script(s) { }
+		/// <summary>
+		/// Create the Actuator with the ScriptEvent to call when the Actuator's call method is invoked and with the calling Body and/or Behavior that will be
+		/// passed to the ScriptEvent when called.
+		/// </summary>
+		/// <param name="script">The ScriptEvent to call when the Actuator's call method is invoked</param>
+		/// <param name="calling">The Body to pass to the ScriptEvent when called</param>
+		/// <param name="behavior">The Behavior to pass to the SciptEvent when called</param>
+		Actuator(ScriptEvent script, Body* calling = nullptr, Behavior* behavior = nullptr) : caller(calling), behavior(behavior), Script(script) { }
 
+		/// <summary>
+		/// Call the ScriptEvent assigned to the Actuator, but pass the Actuator's assigned caller Body and/or Behavior to it instead of the Body or Behavior
+		/// passed to the call method itself. Passing a caller Body or Behavior to this method has no effect.
+		/// </summary>
+		/// <param name="caller">Unused</param>
+		/// <param name="behavior">Unused</param>
 		void call(Body* caller = nullptr, Behavior* behavior = nullptr) override {
 			scriptEvent(ScArgs(this, this->caller, this->behavior)); 
 		}

--- a/src/Core/Scripts/Script.h
+++ b/src/Core/Scripts/Script.h
@@ -27,6 +27,14 @@ namespace CGEngine {
 
 	typedef function<void(ScArgs)> ScriptEvent;
 
+	/// <summary>
+	/// A Script is a stateless or stateful callable object. A Script holds a ScriptEvent function pointer that
+	/// is called when the Script's call method is invoked. The ScriptEvent is passed ScArgs, which contains the
+	/// SciptEvent's calling Script (which can be used to access the Script's input and output DataMaps), the
+	/// Script's calling Body, and/or the Script's calling Behavior. Scripts are typically contained within a ScriptDomain
+	/// and identified by unique id within that domain. Scripts may be called individually by script id within their domain
+	/// or as a group whenever the domain itself is called.
+	/// </summary>
 	class Script : public InputDataController, public OutputDataController {
 	public:
 		Script(ScriptEvent evt);

--- a/src/Core/Types/DataControllers/InputDataController.h
+++ b/src/Core/Types/DataControllers/InputDataController.h
@@ -3,26 +3,54 @@
 #include "../DataMap.h"
 
 namespace CGEngine {
+	/// <summary>
+	/// Data interface for input DataMap with arbitrary data types.
+	/// </summary>
 	class InputDataController {
 	public:
+		/// <summary>
+		/// Overwrite input data with the given DataMap.
+		/// </summary>
+		/// <param name="in">The input DataMap</param>
 		void setInput(DataMap in) {
 			input = in;
 		}
 
+		/// <summary>
+		/// Return the input DataMap.
+		/// </summary>
+		/// <returns>The input DataMap</returns>
 		DataMap getInput() {
 			return input;
 		}
 
+		/// <summary>
+		/// Find the input data of the given T type and key and return it.
+		/// </summary>
+		/// <typeparam name="T">The expected type of input data to retrieve</typeparam>
+		/// <param name="key">The key of input data to retrieve</param>
+		/// <returns>The input data or the T type default value</returns>
 		template<typename T>
 		T getInputData(string key) {
 			return input.getData<T>(key);
 		}
 
+		/// <summary>
+		/// Find the input data pointer of the given T type and key and return it.
+		/// </summary>
+		/// <typeparam name="T">The expected type of the input data pointer to retrieve</typeparam>
+		/// <param name="key">The key of the input data pointer to retrieve</param>
+		/// <returns>The input data pointer or nullptr if not found</returns>
 		template<typename T>
 		T* getInputDataPtr(string key) {
 			return input.getDataPtr<T>(key);
 		}
 
+		/// <summary>
+		/// Set the input data at key to the given value
+		/// </summary>
+		/// <param name="key">The key to add the value to</param>
+		/// <param name="value">The value to add at key</param>
 		void setInputData(string key, any value) {
 			input.setData(key, value);
 		}

--- a/src/Core/Types/DataControllers/OutputDataController.h
+++ b/src/Core/Types/DataControllers/OutputDataController.h
@@ -3,26 +3,54 @@
 #include "../DataMap.h"
 
 namespace CGEngine {
+	/// <summary>
+	/// Data interface for output DataMap with arbitrary data types.
+	/// </summary>
 	class OutputDataController {
 	public:
+		/// <summary>
+		/// Overwrite output data with the given DataMap.
+		/// </summary>
+		/// <param name="out">The output DataMap</param>
 		void setOutput(DataMap out) {
 			output = out;
 		}
 
+		/// <summary>
+		/// Return the output DataMap.
+		/// </summary>
+		/// <returns>The output DataMap</returns>
 		DataMap getOutput() {
 			return output;
 		}
 
+		/// <summary>
+		/// Find the output data of the given T type and key and return it.
+		/// </summary>
+		/// <typeparam name="T">The expected type of output data to retrieve</typeparam>
+		/// <param name="key">The key of output data to retrieve</param>
+		/// <returns>The output data or the T type default value</returns>
 		template<typename T>
 		T getOutputData(string key) {
 			return output.getData<T>(key);
 		}
 
+		/// <summary>
+		/// Find the output data pointer of the given T type and key and return it.
+		/// </summary>
+		/// <typeparam name="T">The expected type of the output data pointer to retrieve</typeparam>
+		/// <param name="key">The key of the output data pointer to retrieve</param>
+		/// <returns>The output data pointer or nullptr if not found</returns>
 		template<typename T>
 		T* getOutputDataPtr(string key) {
 			return output.getDataPtr<T>(key);
 		}
 
+		/// <summary>
+		/// Set the output data at key to the given value
+		/// </summary>
+		/// <param name="key">The key to add the value to</param>
+		/// <param name="value">The value to add at key</param>
 		void setOutputData(string key, any value) {
 			output.setData(key, value);
 		}

--- a/src/Core/Types/DataControllers/ProcessDataController.h
+++ b/src/Core/Types/DataControllers/ProcessDataController.h
@@ -3,26 +3,54 @@
 #include "../DataMap.h"
 
 namespace CGEngine {
+	/// <summary>
+	/// Data interface for process DataMap with arbitrary data types.
+	/// </summary>
 	class ProcessDataController {
 	public:
+		/// <summary>
+		/// Overwrite process data with the given DataMap.
+		/// </summary>
+		/// <param name="data">The process DataMap</param>
 		void setProcess(DataMap data) {
 			process = data;
 		}
 
+		/// <summary>
+		/// Return the process DataMap.
+		/// </summary>
+		/// <returns>The process DataMap</returns>
 		DataMap getProcess() {
 			return process;
 		}
 
+		/// <summary>
+		/// Find the process data of the given T type and key and return it.
+		/// </summary>
+		/// <typeparam name="T">The expected type of process data to retrieve</typeparam>
+		/// <param name="key">The key of process data to retrieve</param>
+		/// <returns>The process data or the T type default value</returns>
 		template<typename T>
 		T getProcessData(string key) {
 			return process.getData<T>(key);
 		}
 
+		/// <summary>
+		/// Find the process data pointer of the given T type and key and return it.
+		/// </summary>
+		/// <typeparam name="T">The expected type of the process data pointer to retrieve</typeparam>
+		/// <param name="key">The key of the process data pointer to retrieve</param>
+		/// <returns>The process data pointer or nullptr if not found</returns>
 		template<typename T>
 		T* getProcessDataPtr(string key) {
 			return process.getDataPtr<T>(key);
 		}
 
+		/// <summary>
+		/// Set the process data at key to the given value
+		/// </summary>
+		/// <param name="key">The key to add the value to</param>
+		/// <param name="value">The value to add at key</param>
 		void setProcessData(string key, any value) {
 			process.setData(key, value);
 		}

--- a/src/Core/Types/DataMap.h
+++ b/src/Core/Types/DataMap.h
@@ -6,20 +6,42 @@
 using namespace std;
 
 namespace CGEngine {
+	/// <summary>
+	/// Stores data of arbitrary type by string key. Data is stored as any type, so its type must be known
+	/// when retrieved to decode it. DataMap is used to store input and output data for Scripts and Behaviors.
+	/// </summary>
 	class DataMap {
 	public:
-		DataMap(map<string, any> d = {}) : data(d) {};
+		/// <summary>
+		/// Construct and initialize the DataMap with the given map of string keys to any values.
+		/// </summary>
+		/// <param name="data">The data to initialize the DataMap with</param>
+		DataMap(map<string, any> data = {}) : data(data) {};
 
+		/// <summary>
+		/// Set the data at the given key to the given value. If the key already exists, it is overwritten.
+		/// </summary>
+		/// <param name="key">The string key of the data</param>
+		/// <param name="val">The value of the data to set</param>
 		void setData(string key, any val) {
 			data[key] = val;
 		}
 
+		/// <summary>
+		/// Remove the data at the given key. If the key does not exist, nothing happens.
+		/// </summary>
+		/// <param name="key">The string key of the data to remove</param>
 		void removeData(string key) {
 			if (data.find(key) != data.end()) {
 				data.erase(key);
 			}
 		}
 
+		/// <summary>
+		/// Return the data at the given key. If the key does not exist, nullopt is returned.
+		/// </summary>
+		/// <param name="key">The string key of the data to return</param>
+		/// <returns>The data at the key or nullopt if not found</returns>
 		optional<any> getData(string key) {
 			if (data.find(key) != data.end()) {
 				return data[key];
@@ -27,6 +49,12 @@ namespace CGEngine {
 			return nullopt;
 		}
 
+		/// <summary>
+		/// Return the data at the given key, cast to T type. If the key does not exist, default value of T type is returned. If the type is not correct, an exception is thrown.
+		/// </summary>
+		/// <typeparam name="T">The type to cast the found data to</typeparam>
+		/// <param name="key">The string key of the data to return</param>
+		/// <returns>The data at the key, cast to T type, or default value of T type if not found. Throws an exception if type is incorrect.</returns>
 		template<typename T>
 		T getData(string key) {
 			static T test;
@@ -36,6 +64,12 @@ namespace CGEngine {
 			return test;
 		}
 
+		/// <summary>
+		/// Return the data pointer at the given key, cast to T type. If the key does not exist, nullptr is returned. If the type is not correct, an exception is thrown.
+		/// </summary>
+		/// <typeparam name="T">The type to cast the found data pointer to</typeparam>
+		/// <param name="key">The string key of the data pointer to return</param>
+		/// <returns>The data pointer at the key, cast to T type, or nullptr if not found. Throws an exception if type is incorrect.</returns>
 		template<typename T>
 		T* getDataPtr(string key) {
 			if (data.find(key) != data.end()) {
@@ -44,6 +78,11 @@ namespace CGEngine {
 			return nullptr;
 		}
 
+		/// <summary>
+		/// Return the data at the given key, then erase it from the data map. If the key does not exist, nullopt is returned.
+		/// </summary>
+		/// <param name="key">The string key of the data to return</param>
+		/// <returns>The data at the key or nullopt if not found</returns>
 		optional<any> pullOutData(string key) {
 			if (data.find(key) != data.end()) {
 				any d = data[key];
@@ -53,6 +92,13 @@ namespace CGEngine {
 			return nullopt;
 		}
 
+		/// <summary>
+		/// Return the data at the given key, cast to T type, then erase it from the data map. If the key does not exist, default value of T type is returned.
+		/// If the type is not correct, an exception is thrown.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="key">The string key of the data to return</param>
+		/// <returns>The data, cast to T type, at the key or default value of T type if not found</returns>
 		template<typename T>
 		T pullOutData(string key) {
 			static T test;
@@ -64,6 +110,9 @@ namespace CGEngine {
 			return test;
 		}
 	private:
+		/// <summary>
+		/// Map of string key to any type value
+		/// </summary>
 		map<string, any> data;
 	};
 }

--- a/src/Core/World/World.cpp
+++ b/src/Core/World/World.cpp
@@ -298,7 +298,7 @@ namespace CGEngine {
         uninitialized.push_back(body);
     }
 
-    void World::startUninitializedBodies() {
+    void World::callUninitializedStart() {
         while (uninitialized.size() > 0) {
             if (auto uninit = uninitialized.back()) {
                 uninit->start();
@@ -317,7 +317,9 @@ namespace CGEngine {
 
             while (window->isOpen()) {
                 updateTime();
-                startUninitializedBodies();
+				if (uninitialized.size() > 0) {
+					callUninitializedStart();
+				}
                 callScripts(onUpdateEvent);
                 input->gather();
                 
@@ -341,7 +343,7 @@ namespace CGEngine {
             body = root;
         }
 
-        body->apply([&scriptDomain](Body* b) { if (scriptDomain != "delete" || b != world->root) { b->callScripts(scriptDomain); } });
+        body->apply([&scriptDomain](Body* b) { if (scriptDomain != onDeleteEvent || b != world->root) { b->callScripts(scriptDomain); } });
     }
 
     void World::addDefaultExitActuator() {

--- a/src/Core/World/World.h
+++ b/src/Core/World/World.h
@@ -73,7 +73,7 @@ namespace CGEngine {
         void initSceneList();
         //Update World
         void updateTime();
-        void startUninitializedBodies();
+        void callUninitializedStart();
 
         //Scenes
         map<string, Behavior*> scenes;


### PR DESCRIPTION
- Behavior.GetId() now returns an optional id, allowing Behaviors to be constructed without a Body (though this has no immediate use cases)
- Adds a lot of documentation commenting to Scripts, Actuators, Behaviors, Input/Output/ProcessDataControllers, and DataMap