### PR TITLE
Implement static script domains for start, update, delete

### DIFF
--- a/src/Core/Body/Body.cpp
+++ b/src/Core/Body/Body.cpp
@@ -126,7 +126,7 @@ namespace CGEngine {
 
     void Body::start() {
         if (!initialized) {
-            callScripts(onStartEvent);
+            callStaticScripts(StartDomain);
             initialized = true;
         }
     }
@@ -661,6 +661,11 @@ namespace CGEngine {
 
         behaviors.forEach([&domain](Behavior* behavior) { behavior->callDomain(domain); });
         scripts.callDomain(domain);
+    }
+
+    void Body::callStaticScripts(StaticScriptDomain domainId) {
+		if (domainId < 0 || domainId > 2) return;
+		scripts.callStaticDomain(domainId);
     }
 
     void Body::callScriptsWithData(string domain, DataMap data) {

--- a/src/Core/Body/Body.h
+++ b/src/Core/Body/Body.h
@@ -371,6 +371,11 @@ namespace CGEngine {
         /// <param name="domain">The domain of the scripts to call</param>
         void callScripts(string domain);
         /// <summary>
+		/// Call each script within the domain at domainId (0="start", 1="update", 2="delete")
+        /// </summary>
+        /// <param name="domainId">The domain id of the scripts to call (0="start", 1="update", 2="delete")</param>
+        void callStaticScripts(StaticScriptDomain domainId);
+        /// <summary>
         /// Call each script within the domain, providing the indicated input data
         /// </summary>
         /// <param name="domain">The domain of the scripts to call</param>

--- a/src/Core/Scripts/ScriptMap.cpp
+++ b/src/Core/Scripts/ScriptMap.cpp
@@ -87,6 +87,17 @@ namespace CGEngine {
 		}
 	}
 
+	void ScriptMap::callStaticDomain(StaticScriptDomain domainId, Behavior* behavior, bool logUpdate) {
+		if (domainId < 0 || domainId > 2) return;
+		ScriptDomain* domain = staticDomains[domainId];
+		if (domain) {
+			if (domain->getName() != onUpdateEvent || logUpdate) {
+				log(this, LogInfo, "Calling Domain '{}'", domain->getName());
+			}
+			domain->callDomain(owner, behavior);
+		}
+	}
+
 	void ScriptMap::callScript(string domainName, size_t scriptId, Behavior* behavior) {
 		if (ScriptDomain* domain = getDomain(domainName)) {
 			log(this, LogInfo, "Calling Script '{}'.'{}'", domain->getName(), to_string(scriptId));
@@ -119,6 +130,15 @@ namespace CGEngine {
 	ScriptDomain* ScriptMap::addDomain(string domainName) {
 		domains[domainName] = new ScriptDomain(domainName, ownerName);
 		log(this, LogInfo, "Added Domain '{}'", domainName);
+		// Cache update domain reference
+		if (domainName == onStartEvent) {
+			staticDomains[0] = domains[domainName];
+		} else if (domainName == onUpdateEvent) {
+			staticDomains[1] = domains[domainName];
+		} else if (domainName == onDeleteEvent) {
+			staticDomains[2] = domains[domainName];
+		}
+
 		return domains[domainName];
 	}
 

--- a/src/Core/Scripts/ScriptMap.h
+++ b/src/Core/Scripts/ScriptMap.h
@@ -4,6 +4,12 @@
 #include "../Logging/Logging.h"
 
 namespace CGEngine {
+	enum StaticScriptDomain {
+		StartDomain = 0,
+		UpdateDomain = 1,
+		DeleteDomain = 2
+	};
+
 	class ScriptMap : public EngineSystem{
 	public:
 		ScriptMap(Body* o);
@@ -15,6 +21,7 @@ namespace CGEngine {
 		void clearDomain(string domainName);
 		void clear();
 		void callDomain(string domainName, Behavior* behavior = nullptr, bool logUpdate = false);
+		void callStaticDomain(StaticScriptDomain domainId, Behavior* behavior = nullptr, bool logUpdate = false);
 		void callScript(string domainName, size_t scriptId, Behavior* behavior = nullptr);
 		void callDomainWithData(string domainName, Behavior* behavior = nullptr, DataMap input = DataMap(), bool logUpdate = false);
 		void callScriptWithData(string domainName, size_t scriptId, Behavior* behavior = nullptr, DataMap input = DataMap());
@@ -30,5 +37,6 @@ namespace CGEngine {
 		ScriptDomain* getDomain(string domainName);
 		void deleteDomains();
 		void deleteDomain(ScriptDomain* domain);
+		ScriptDomain* staticDomains[3] = { nullptr, nullptr, nullptr };
 	};
 }

--- a/src/Core/World/World.cpp
+++ b/src/Core/World/World.cpp
@@ -134,7 +134,7 @@ namespace CGEngine {
         if (input != nullptr) {
             input->clear();
         }
-        root->apply([](Body* b) { b->callScripts(onDeleteEvent); });
+        root->apply([](Body* b) { b->callStaticScripts(DeleteDomain); });
         running = false;
         window->close();
     }
@@ -320,7 +320,7 @@ namespace CGEngine {
 				if (uninitialized.size() > 0) {
 					callUninitializedStart();
 				}
-                callScripts(onUpdateEvent);
+                callStaticScripts(UpdateDomain);
                 input->gather();
                 
                 if (window->isOpen()) {
@@ -344,6 +344,16 @@ namespace CGEngine {
         }
 
         body->apply([&scriptDomain](Body* b) { if (scriptDomain != onDeleteEvent || b != world->root) { b->callScripts(scriptDomain); } });
+    }
+
+    void World::callStaticScripts(StaticScriptDomain scriptDomainId, Body* body) {
+		if (scriptDomainId < 0 || scriptDomainId > 2) return;
+
+        if (body == nullptr) {
+            body = root;
+        }
+
+        body->apply([&scriptDomainId](Body* b) { if (scriptDomainId != 0 || b != world->root) { b->callStaticScripts(scriptDomainId); } });
     }
 
     void World::addDefaultExitActuator() {

--- a/src/Core/World/World.h
+++ b/src/Core/World/World.h
@@ -23,6 +23,7 @@ namespace CGEngine {
 
         //Scripts
         void callScripts(string scriptDomain, Body* body = nullptr);
+        void callStaticScripts(StaticScriptDomain scriptDomainId, Body* body = nullptr);
         void addDefaultExitActuator();
 
         //Utility
@@ -37,9 +38,7 @@ namespace CGEngine {
         void setBoundsRenderingEnabled(bool enabled);
         bool getBoundsRenderingEnabled() const;
         void setBoundsColor(Color color);
-        void setBoundsColor(Color color, Body* body);
         void setBoundsThickness(float thickness);
-        void setBoundsThickness(float thickness, Body* body);
 
         //Scenes
         void addScene(string sceneName, Behavior* scene);


### PR DESCRIPTION
- Implemented static ScriptDomains in ScriptMap for start, update, and delete domains. Using string lookups in a map are slower than integer lookups and because we know these three domains will be present, we can assign each to an index array.