### PR TITLE
Body entity ref to unique pointer with entity value constructor

### DIFF
--- a/src/Core/Mesh/Model.cpp
+++ b/src/Core/Mesh/Model.cpp
@@ -124,7 +124,7 @@ namespace CGEngine {
 		}
 
 		// Create null Mesh Body root
-		optional<id_t> rootId = assets.create<Body>(sourcePath.append(".Root"), new Mesh(nullptr));
+		optional<id_t> rootId = assets.create<Body>(sourcePath.append(".Root"), Mesh(nullptr));
 		if (rootId.has_value()) {
 			Body* rootBody = assets.get<Body>(rootId.value());
 
@@ -194,8 +194,8 @@ namespace CGEngine {
 		}
 
 		// Create a mesh for this node (even if empty)
-		Mesh* mesh = new Mesh(node->meshData, nodeTransform, nodeMaterials);
-		mesh->setModelId(getId());
+		Mesh mesh = Mesh(node->meshData, nodeTransform, nodeMaterials);
+		mesh.setModelId(getId());
 
 		// Create and attach child body
 		optional<id_t> bodyId = assets.create<Body>(sourcePath.append(node->nodeName), mesh);

--- a/src/Core/World/World.cpp
+++ b/src/Core/World/World.cpp
@@ -1,6 +1,7 @@
 #include "World.h"
 #include "../Engine/Engine.h"
 #include "../../Standard/Models/CommonModels.h"
+using std::make_unique;
 
 namespace CGEngine {
     World::World() : root(assets.get<Body>(assets.create<Body>("Root", true).value())) {
@@ -15,7 +16,13 @@ namespace CGEngine {
     void World::initializeConsole() {
         if (!consoleInitialized && consoleFeatureEnabled) {
             Font* defaultFont = assets.get<FontResource>(assets.getDefaultId<FontResource>().value())->getFont();
-            consoleTextBox = new Body(new Text(*defaultFont), Transformation());
+            optional<id_t> consoleId = assets.create<Body>("Console", Text(*defaultFont), Transformation());
+			if (!consoleId.has_value()) {
+				log(this, LogError, "Failed to create console body");
+				return;
+			}
+
+            consoleTextBox = assets.get<Body>(consoleId.value());
             consoleTextBox->moveToAlignment(Alignment::Bottom_Left);
             consoleTextBox->move({ 20,-35 });
             consoleTextBox->zOrder = 100;


### PR DESCRIPTION
- Replace Transformable* entity reference in Body with unique_ptr<Transformable> entity reference
- Use value forwarding in Body constructor to construct the Transformable inline and avoid unique_ptr in Body constructor