### PR TITLE
Defer Body parenting & transform to start(), parent to id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,42 @@
-#CGEngine v0.1
+#CG Engine
 
 THIS SOFTWARE IS IN ALPHA DEVELOPMENT AND IS RELEASED AS-IS. FEATURES ARE LIKELY TO CHANGE WITHOUT NOTICE.
 
 This C++ interaction library allows you to create real-time, scriptable visual interfaces and games using composable Bodies, Behaviors, Scripts, and Timers.
 
 This project template is built on the SFML CMake GitHub template. Instructions for using that template are below and many should be the same for this project template, but they have not been reviewed or confirmed.
+
+#CG Engine Details
+CG Engine
+- C++ 2D/3D scene graph scripting engine
+- Libraries: SFML, OpenGL, CMake, Assimp
+
+Engine Systems
+- Engine defines global extern objects (World, Renderer, AssetManager, etc)
+- AssetManager has a Type-to-UniqueDomain map of asset pointer (IResource) to unique id within that domain
+- Assets managed by AssetManager should be referenced by id wherever possible
+- Renderer handles OpenGL to render Meshes and/or SFML draw functions to draw SFML entities
+- World holds the root Body of the scene graph and other world state
+- InputMap has a InputCondition-to-UniqueDomain map of Script to unique id.
+- InputMap gathers input and calls domains when input matches InputCondition for the domain
+
+Engine Classes
+- Body holds entities, like Mesh or SFML's Shape, Sprite, and Text
+- Body holds ScriptMap and can call scripts by domain string. Start, Update, and Delete domains called by engine.
+- Body holds vector of Behaviors. Behavior Start, Update, and Delete called with Body.
+- ScriptMap has a string-to-UniqueDomain map of Script to unique id.
+- Script holds ScriptEvent function pointer that takes ScArgs (script Script*, caller Body*, behave Behavior*)
+- Script holds input & output DataMaps for state and input/output
+- Actuators are Scripts with caller and behavior reference that can be called from anywhere (as InputMap does)
+- Behavior holds a ScriptMap and input, output, & process DataMaps for state and input/output
+- Behavior does not have entity, like Body
+- Mesh entities are Drawable and Transformable OpenGL 3D entities
+- Models are compositions of Bodies with Meshes and may be imported via Assimp
+- Shaders are loaded from file, to allow developers to define custom shaders
+- Programs are loaded from shaders
+- Materials use a string-to-any value map of parameters to allow developers to define custom materials
+
+Keep these implementation details in mind when analyzing classes and providing suggestions. If you notice code that does not support the above implementation details, raise a warning. Always use logic and reasoning when suggesting new code and be clear where code has changed.
 
 # CMake SFML Project Template
 

--- a/src/Core/Body/Body.h
+++ b/src/Core/Body/Body.h
@@ -54,7 +54,7 @@ namespace CGEngine {
         template<typename T, typename = std::enable_if_t<std::is_base_of_v<Transformable, std::decay_t<T>>>>
         Body(T&& entity,
             Transformation handle = Transformation(),
-            Body* parent = nullptr,
+            std::optional<id_t> parentId = std::nullopt,
             Vector2f align = { 0,0 })
             : Body() // Call default constructor first
         {
@@ -63,20 +63,12 @@ namespace CGEngine {
 
             createBoundsRect();
 
-            this->parent = parent;
-            if (parent != nullptr) {
-                attach(parent);
-            }
-            else {
-                this->parent = world->getRoot();
-                attach(world->getRoot());
-            }
+            this->parentId = parentId;
+            this->initialHandle = handle;
+            this->initialAlignment = align;
+            this->needsParentingAndTransformInit = true;
 
             world->addUninitialized(this);
-            moveToAlignment(align);
-            setPosition(handle.position);
-            setRotation(handle.angle);
-            setScale(handle.scale);
         }
 
         virtual ~Body();
@@ -90,6 +82,9 @@ namespace CGEngine {
         /// </summary>
         /// <param name="name">The new name</param>
         void setName(string name);
+
+        std::optional<id_t> getParentId() const { return parentId; }
+        Body* getParent() const;
         /// <summary>
         /// Return the drawn Shape as an object of the indicated type
         /// </summary>
@@ -657,7 +652,10 @@ namespace CGEngine {
         /// <summary>
         /// The Body whose transform is the parent of this Body's transform
         /// </summary>
-        Body* parent = nullptr;
+        std::optional<id_t> parentId;
+        Transformation initialHandle;
+        Vector2f initialAlignment;
+        bool needsParentingAndTransformInit = true;
         /// <summary>
         /// The Bodies that are attached to (and inherit the Transform of) this Body
         /// </summary>

--- a/src/Core/World/Renderer.cpp
+++ b/src/Core/World/Renderer.cpp
@@ -373,8 +373,10 @@ namespace CGEngine {
 		}
 
 		// Combine with parent transform
-		if (body->parent && body->parent != world->getRoot()) {
-			glm::mat4 modelMatrix = getCombinedModelMatrix(body->parent) * localTransform;
+		if (body->parentId.has_value() && body->parentId != world->getRoot()->getId()) {
+			Body* parent = assets.get<Body>(body->parentId.value());
+			if (!parent) return localTransform;
+			glm::mat4 modelMatrix = getCombinedModelMatrix(parent) * localTransform;
 			body->globalTransform = glmToTransform(modelMatrix);
 			return modelMatrix;
 		}


### PR DESCRIPTION
- Updated Body constructor and logic to defer parenting and transforming Body until Body.start()
- Changed Body.parent from raw pointer to AssetManager id